### PR TITLE
Default peer service name to blank as it is required in Thrift Endpoint

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -72,7 +72,7 @@ public class Span implements io.opentracing.Span {
     public Endpoint getPeer() {
         synchronized (this) {
             if (peer == null) {
-                peer = new Endpoint();
+                peer = new Endpoint(0, (short) 0, "");
             }
         }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -21,14 +21,14 @@
  */
 package com.uber.jaeger;
 
+import com.twitter.zipkin.thriftjava.Endpoint;
+import com.uber.jaeger.utils.Utils;
+import io.opentracing.tag.Tags;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.twitter.zipkin.thriftjava.Endpoint;
-import com.uber.jaeger.utils.Utils;
-import io.opentracing.tag.Tags;
 
 public class Span implements io.opentracing.Span {
     private final Tracer tracer;
@@ -71,12 +71,18 @@ public class Span implements io.opentracing.Span {
 
     public Endpoint getPeer() {
         synchronized (this) {
+            return peer;
+        }
+
+    }
+
+    Endpoint getOrMakePeer() {
+        synchronized (this) {
             if (peer == null) {
                 peer = new Endpoint(0, (short) 0, "");
             }
+            return peer;
         }
-
-        return peer;
     }
 
     public Map<String, Object> getTags() {
@@ -179,17 +185,17 @@ public class Span implements io.opentracing.Span {
         }
 
         if (key.equals(Tags.PEER_HOST_IPV4.getKey()) && value instanceof Integer) {
-            getPeer().setIpv4((Integer) value);
+            getOrMakePeer().setIpv4((Integer) value);
             return true;
         }
 
         if (key.equals(Tags.PEER_PORT.getKey()) && value instanceof Number) {
-            getPeer().setPort(((Number) value).shortValue());
+            getOrMakePeer().setPort(((Number) value).shortValue());
             return true;
         }
 
         if (key.equals(Tags.PEER_SERVICE.getKey()) && value instanceof String) {
-            getPeer().setService_name((String) value);
+            getOrMakePeer().setService_name((String) value);
             return true;
         }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -76,7 +76,7 @@ public class Span implements io.opentracing.Span {
 
     }
 
-    Endpoint getOrMakePeer() {
+    private Endpoint getOrMakePeer() {
         synchronized (this) {
             if (peer == null) {
                 peer = new Endpoint(0, (short) 0, "");

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -73,8 +73,8 @@ public class Tracer implements io.opentracing.Tracer {
         Map<String, Object> tags = new HashMap<>();
         tags.put("jaeger.version", Tracer.VERSION);
         String hostname = getHostName();
-        if (getHostName() != null) {
-            tags.put("jaeger.hostname", getHostName());
+        if (hostname != null) {
+            tags.put("jaeger.hostname", hostname);
         }
         this.tags = Collections.unmodifiableMap(tags);
 


### PR DESCRIPTION
Fixes #45