### PR TITLE
Tolerate reads of 128 bit X-B3-TraceId

### DIFF
--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -4,14 +4,14 @@ apply plugin: 'com.github.kt3k.coveralls'
 description = 'Integration library for Zipkin'
 
 dependencies {
-    compile group: 'io.zipkin.reporter', name: 'zipkin-reporter', version: '0.4.2'
-    compile group: 'io.zipkin.reporter', name: 'zipkin-sender-urlconnection', version: '0.4.2'
+    compile group: 'io.zipkin.reporter', name: 'zipkin-reporter', version: '0.4.4'
+    compile group: 'io.zipkin.reporter', name: 'zipkin-sender-urlconnection', version: '0.4.4'
     compile project(':jaeger-core')
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
-    testCompile group: 'io.zipkin.java', name: 'zipkin-junit', version: '1.8.3'
-    testCompile group: 'io.zipkin.brave', name: 'brave-http', version: '3.10.0'
+    testCompile group: 'io.zipkin.java', name: 'zipkin-junit', version: '1.11.1'
+    testCompile group: 'io.zipkin.brave', name: 'brave-http', version: '3.11.0'
 }
 
 jacocoTestReport {


### PR DESCRIPTION
The first step of transitioning to 128bit `X-B3-TraceId` is tolerantly reading 32 character long ids by throwing away the high bits (any characters left of 16 characters). This allows the tracing system to more flexibly introduce 128bit trace id support in the future.

Ex. when `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124` is received, parse the lower 64 bits (right most 16 characters ex48485a3953bb6124) as the trace id.

See https://github.com/openzipkin/b3-propagation/issues/6