### PR TITLE
Support debug traces via HTTP header "jaeger-debug-id"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changes by Version
 ==================
 
+0.10.0 (unreleased)
+-------------------
+
+- Support debug traces via HTTP header "jaeger-debug-id"
+
+
 0.9.0 (2016-09-12)
 -------------------
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
     apply plugin: 'idea' // intellij support
 
     group = 'com.uber.jaeger'
-    version = '0.9.1-SNAPSHOT'
+    version = '0.10.0-SNAPSHOT'
 
     task wrapper(type: Wrapper) {
         gradleVersion = '2.12' //version required

--- a/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
@@ -36,4 +36,13 @@ public class Constants {
      * Span tag key to describe the parameter of the sampler used on the root span.
      */
     public static final String SAMPLER_PARAM_TAG_KEY = "sampler.param";
+
+    /**
+     * The name of HTTP header or a TextMap carrier key which, if found
+     * in the carrier, forces the trace to be sampled as "debug" trace.
+     * The value of the header is recorded as the tag on the root span,
+     * so that the trace can be found in the UI using this value as a
+     * correlation ID.
+     */
+    public static final String DEBUG_ID_HEADER_KEY = "jaeger-debug-id";
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
@@ -154,7 +154,7 @@ public class SpanContext implements io.opentracing.SpanContext {
      * Create a new dummy SpanContext as a container for debugID string.
      * This is used when "jaeger-debug-id" header is passed in the request
      * headers and forces the trace to be sampled as debug trace, and the
-     * value of header recorded as a span tag to server as searchable
+     * value of header recorded as a span tag to serve as a searchable
      * correlation ID.
      *
      * @param debugID arbitrary string used as correlation ID

--- a/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
@@ -21,10 +21,10 @@
  */
 package com.uber.jaeger;
 
-import com.uber.jaeger.exceptions.*;
+import com.uber.jaeger.exceptions.EmptyTracerStateStringException;
+import com.uber.jaeger.exceptions.MalformedTracerStateStringException;
 
 import java.math.BigInteger;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,12 +38,13 @@ public class SpanContext implements io.opentracing.SpanContext {
     private final long parentID;
     private final byte flags;
     private final Map<String, String> baggage;
+    private final String debugID;
 
     public SpanContext(long traceID, long spanID, long parentID, byte flags) {
-        this(traceID, spanID, parentID, flags, Collections.<String, String>emptyMap());
+        this(traceID, spanID, parentID, flags, Collections.<String, String>emptyMap(), null);
     }
 
-    SpanContext(long traceID, long spanID, long parentID, byte flags, Map<String, String> baggage) {
+    SpanContext(long traceID, long spanID, long parentID, byte flags, Map<String, String> baggage, String debugID) {
         if (baggage == null) {
             throw new NullPointerException();
         }
@@ -52,6 +53,7 @@ public class SpanContext implements io.opentracing.SpanContext {
         this.parentID = parentID;
         this.flags = flags;
         this.baggage = baggage;
+        this.debugID = debugID;
     }
 
     @Override
@@ -123,14 +125,49 @@ public class SpanContext implements io.opentracing.SpanContext {
     public SpanContext withBaggageItem(String key, String val) {
         Map<String, String> newBaggage = new HashMap<>(this.baggage);
         newBaggage.put(key, val);
-        return new SpanContext(traceID, spanID, parentID, flags, newBaggage);
+        return new SpanContext(traceID, spanID, parentID, flags, newBaggage, debugID);
     }
 
     public SpanContext withBaggage(Map<String, String> newBaggage) {
-        return new SpanContext(traceID, spanID, parentID, flags, newBaggage);
+        return new SpanContext(traceID, spanID, parentID, flags, newBaggage, debugID);
     }
 
     public SpanContext withFlags(byte flags) {
-        return new SpanContext(traceID, spanID, parentID, flags, baggage);
+        return new SpanContext(traceID, spanID, parentID, flags, baggage, debugID);
+    }
+
+    /**
+     * @return true when the instance of the context is only used to return
+     * the debug/correlation ID from extract() method. This happens in the
+     * situation when "jaeger-debug-id" header is passed in the carrier to
+     * the extract() method, but the request otherwise has no span context in it.
+     * Previously this would've returned null from the extract method,
+     * but now it returns a dummy context with only debugID filled in.
+     *
+     * @see Constants#DEBUG_ID_HEADER_KEY
+     */
+    boolean isDebugIDContainerOnly() {
+        return traceID == 0 && debugID != null;
+    }
+
+    /**
+     * Create a new dummy SpanContext as a container for debugID string.
+     * This is used when "jaeger-debug-id" header is passed in the request
+     * headers and forces the trace to be sampled as debug trace, and the
+     * value of header recorded as a span tag to server as searchable
+     * correlation ID.
+     *
+     * @param debugID arbitrary string used as correlation ID
+     *
+     * @return new dummy SpanContext that serves as a container for debugID only.
+     *
+     * @see Constants#DEBUG_ID_HEADER_KEY
+     */
+    public static SpanContext withDebugID(String debugID) {
+        return new SpanContext(0, 0, 0, (byte)0, Collections.<String, String>emptyMap(), debugID);
+    }
+
+    String getDebugID() {
+        return debugID;
     }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.jaeger;
+
+import com.uber.jaeger.reporters.InMemoryReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PropagationTest {
+    @Test
+    public void testDebugCorrelationID() {
+        Tracer tracer = new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true))
+                .build();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.DEBUG_ID_HEADER_KEY, "Coraline");
+        TextMap carrier = new TextMapExtractAdapter(headers);
+        SpanContext spanContext = (SpanContext) tracer.extract(Format.Builtin.TEXT_MAP, carrier);
+        assertTrue(spanContext.isDebugIDContainerOnly());
+        assertEquals("Coraline", spanContext.getDebugID());
+        Span span = (Span) tracer.buildSpan("span").asChildOf(spanContext).start();
+        spanContext = (SpanContext) span.context();
+        assertTrue(spanContext.isSampled());
+        assertTrue(spanContext.isDebug());
+        assertEquals("Coraline", span.getTags().get(Constants.DEBUG_ID_HEADER_KEY));
+    }
+}

--- a/jaeger-core/src/test/java/com/uber/jaeger/SpanContextTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/SpanContextTest.java
@@ -27,20 +27,20 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class TraceContextTest {
+public class SpanContextTest {
 
     @Test(expected=MalformedTracerStateStringException.class)
-    public void testContextFromStringMalformedException() throws EmptyTracerStateStringException, MalformedTracerStateStringException {
+    public void testContextFromStringMalformedException() throws Exception {
         SpanContext.contextFromString("ff:ff:ff");
     }
 
     @Test(expected=EmptyTracerStateStringException.class)
-    public void testContextFromStringEmptyException() throws EmptyTracerStateStringException, MalformedTracerStateStringException {
+    public void testContextFromStringEmptyException() throws Exception {
         SpanContext.contextFromString("");
     }
 
     @Test
-    public void testContextFromString() throws EmptyTracerStateStringException, MalformedTracerStateStringException {
+    public void testContextFromString() throws Exception {
         SpanContext context = SpanContext.contextFromString("ff:dd:cc:4");
         assertEquals(context.getTraceID(), 255);
         assertEquals(context.getSpanID(), 221);


### PR DESCRIPTION
Recognize HTTP header or a TextMap key `jaeger-debug-id` which, if found in the carrier, forces the trace to be sampled as "debug" trace. The value of the header is recorded as the tag on the root span, so that the trace can be found in the UI using this value as a correlation ID.
