### PR TITLE
Remove call to Github API to get current branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,7 @@ after_success:
 - pushd 'jaeger-crossdock'
 - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 - export REPO=jaegertracing/xdock-java
-- export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - docker build -f Dockerfile -t $REPO:$COMMIT .


### PR DESCRIPTION
Now that Travis has shipped travis-ci/travis-ci#1633, we don't need to make a call to the Github API to get the current branch name from both PUSH and PR builds.