### PR TITLE
Downgrade to thrift 0.9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 ext.opentracingVersion = '0.15.0'
 ext.guavaVersion = '18.0'
-ext.apacheThriftVersion = '0.9.3'
+ext.apacheThriftVersion = '0.9.2'
 ext.jerseyVersion = '2.22.2'
 ext.slf4jVersion = '1.7.16'
 ext.jacksonVersion = '2.7.4'

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,16 @@ subprojects {
     classes.dependsOn tasks.verifyFormatting
 
     apply from: '../gradle/publish.gradle'
+    test {
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+
+        // remove standard output/error logging from --info builds
+        // by assigning only 'failed' and 'skipped' events
+        info.events = ["failed", "skipped"]
+       }
+    }
 }
 
 configure(subprojects.findAll {it.name != 'jaeger-thrift'}) {

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -12,7 +12,6 @@ compileThrift {
     sourceDir "${projectDir}/../idl/thrift"
     outputDir 'src/main/gen-java'
     generator 'java', 'private-members'
-    debug true
     createGenFolder false
 }
 

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -12,6 +12,7 @@ compileThrift {
     sourceDir "${projectDir}/../idl/thrift"
     outputDir 'src/main/gen-java'
     generator 'java', 'private-members'
+    debug true
     createGenFolder false
 }
 

--- a/travis/docker-thrift/thrift
+++ b/travis/docker-thrift/thrift
@@ -2,7 +2,7 @@
 
 pwd=$(dirname ${PWD})
 
-THRIFT_VER=0.9.3
+THRIFT_VER=0.9.2
 THRIFT_IMG=thrift:${THRIFT_VER}
 THRIFT="docker run -v ${pwd}:/data ${THRIFT_IMG} thrift"
 


### PR DESCRIPTION
- This is to match tchannel-java's thrift dependency
  https://github.com/uber/tchannel-java which is often
  used with jaeger at Uber