### PR TITLE
allow runnables without current span to run

### DIFF
--- a/jaeger-context/src/main/java/com/uber/jaeger/context/Callable.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/Callable.java
@@ -31,17 +31,25 @@ public class Callable<T> implements java.util.concurrent.Callable<T> {
   public Callable(java.util.concurrent.Callable<T> wrappedCallable, TraceContext traceContext) {
     this.wrappedCallable = wrappedCallable;
     this.traceContext = traceContext;
-    currentSpan = traceContext.getCurrentSpan();
+    if (!traceContext.isEmpty()) {
+      this.currentSpan = traceContext.getCurrentSpan();
+    } else {
+      this.currentSpan = null;
+    }
   }
 
   @Override
   public T call() throws Exception {
-    traceContext.push(currentSpan);
+    if (currentSpan != null) {
+      traceContext.push(currentSpan);
+    }
 
     try {
       return wrappedCallable.call();
     } finally {
-      traceContext.pop();
+      if (currentSpan != null) {
+        traceContext.pop();
+      }
     }
   }
 }

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/Runnable.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/Runnable.java
@@ -31,16 +31,25 @@ public class Runnable implements java.lang.Runnable {
   public Runnable(java.lang.Runnable wrappedRunnable, TraceContext traceContext) {
     this.wrappedRunnable = wrappedRunnable;
     this.traceContext = traceContext;
-    this.currentSpan = traceContext.getCurrentSpan();
+    if (!traceContext.isEmpty()) {
+      this.currentSpan = traceContext.getCurrentSpan();
+    } else {
+      this.currentSpan = null;
+    }
   }
 
   @Override
   public void run() {
-    traceContext.push(currentSpan);
+    if (currentSpan != null) {
+      traceContext.push(currentSpan);
+    }
+
     try {
       wrappedRunnable.run();
     } finally {
-      traceContext.pop();
+      if (currentSpan != null) {
+        traceContext.pop();
+      }
     }
   }
 }

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/CallableTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/CallableTest.java
@@ -41,6 +41,7 @@ public class CallableTest {
     traceContext = mock(TraceContext.class);
     when(traceContext.getCurrentSpan()).thenReturn(span);
     when(traceContext.pop()).thenReturn(span);
+    when(traceContext.isEmpty()).thenReturn(false);
   }
 
   @Test
@@ -52,9 +53,25 @@ public class CallableTest {
 
     jaegerCallable.call();
 
+    verify(traceContext, times(1)).isEmpty();
     verify(traceContext, times(1)).push(span);
     verify(traceContext, times(1)).getCurrentSpan();
     verify(traceContext, times(1)).pop();
+    verify(wrappedCallable, times(1)).call();
+    verifyNoMoreInteractions(traceContext, wrappedCallable);
+  }
+
+  @Test
+  public void testInstrumentedCallableNoCurrentSpan() throws Exception {
+    Callable wrappedCallable = mock(Callable.class);
+    when(wrappedCallable.call()).thenReturn(span);
+    when(traceContext.isEmpty()).thenReturn(true);
+
+    Callable<Span> jaegerCallable = new Callable<>(wrappedCallable, traceContext);
+
+    jaegerCallable.call();
+
+    verify(traceContext, times(1)).isEmpty();
     verify(wrappedCallable, times(1)).call();
     verifyNoMoreInteractions(traceContext, wrappedCallable);
   }

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/RunnableTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/RunnableTest.java
@@ -41,6 +41,7 @@ public class RunnableTest {
     traceContext = mock(TraceContext.class);
     when(traceContext.getCurrentSpan()).thenReturn(span);
     when(traceContext.pop()).thenReturn(span);
+    when(traceContext.isEmpty()).thenReturn(false);
   }
 
   @Test
@@ -53,6 +54,21 @@ public class RunnableTest {
     verify(traceContext, times(1)).push(span);
     verify(traceContext, times(1)).pop();
     verify(traceContext, times(1)).getCurrentSpan();
+    verify(traceContext, times(1)).isEmpty();
+    verify(wrappedRunnable, times(1)).run();
+    verifyNoMoreInteractions(traceContext, wrappedRunnable);
+  }
+
+  @Test
+  public void testIntrumentedRunnableNoCurrentSpan() {
+    when(traceContext.isEmpty()).thenReturn(true);
+
+    Runnable wrappedRunnable = mock(Runnable.class);
+    Runnable runnable = new Runnable(wrappedRunnable, traceContext);
+
+    runnable.run();
+
+    verify(traceContext, times(1)).isEmpty();
     verify(wrappedRunnable, times(1)).run();
     verifyNoMoreInteractions(traceContext, wrappedRunnable);
   }

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracedExecutorServiceTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracedExecutorServiceTest.java
@@ -56,6 +56,7 @@ public class TracedExecutorServiceTest {
     traceContext = mock(TraceContext.class);
     when(traceContext.pop()).thenReturn(span);
     when(traceContext.getCurrentSpan()).thenReturn(span);
+    when(traceContext.isEmpty()).thenReturn(false);
     tracedExecutorService = new TracedExecutorService(wrappedExecutorService, traceContext);
     callableList =
         new ArrayList<java.util.concurrent.Callable<Span>>() {
@@ -112,6 +113,7 @@ public class TracedExecutorServiceTest {
 
     tracedExecutorService.submit(wrappedCallable);
 
+    verify(traceContext, times(1)).isEmpty();
     verify(traceContext, times(1)).getCurrentSpan();
     verify(wrappedExecutorService, times(1)).submit(any(Callable.class));
     verifyNoMoreInteractions(wrappedExecutorService, wrappedCallable, traceContext);
@@ -123,6 +125,7 @@ public class TracedExecutorServiceTest {
 
     tracedExecutorService.submit(wrappedRunnable);
 
+    verify(traceContext, times(1)).isEmpty();
     verify(traceContext, times(1)).getCurrentSpan();
     verify(wrappedExecutorService).submit(any(Runnable.class));
     verifyNoMoreInteractions(wrappedExecutorService, wrappedRunnable, traceContext);
@@ -133,6 +136,7 @@ public class TracedExecutorServiceTest {
     tracedExecutorService.invokeAll(callableList);
 
     verify(wrappedExecutorService).invokeAll(any(List.class));
+    verify(traceContext, times(callableList.size())).isEmpty();
     verify(traceContext, times(callableList.size())).getCurrentSpan();
     verifyNoMoreInteractions(wrappedExecutorService, traceContext);
   }
@@ -142,6 +146,7 @@ public class TracedExecutorServiceTest {
     tracedExecutorService.invokeAny(callableList);
 
     verify(wrappedExecutorService).invokeAny(any(List.class));
+    verify(traceContext, times(callableList.size())).isEmpty();
     verify(traceContext, times(callableList.size())).getCurrentSpan();
     verifyNoMoreInteractions(wrappedExecutorService, traceContext);
   }
@@ -152,6 +157,7 @@ public class TracedExecutorServiceTest {
 
     tracedExecutorService.execute(wrappedRunnable);
 
+    verify(traceContext, times(1)).isEmpty();
     verify(traceContext, times(1)).getCurrentSpan();
     verify(wrappedExecutorService).execute(any(Runnable.class));
     verifyNoMoreInteractions(wrappedExecutorService, traceContext);


### PR DESCRIPTION
Otherwise if a Runnable is submitted without a current span in the TraceContext, it will blow up with a empty stack exception.

This was necessary as I wanted to use a global executor service that was decorated with `TracedExecutorService`. We haven't yet been able to switch over everything to necessarily have a span, so I made the `TracedExecutorService` and friends handle that more gracefully.

I could instead push this further up into the `TracedExecutorService` instead of mucking with the Runnable and Callable. 

Thoughts?