### PR TITLE
set host on all zipkin annotations for queries

### DIFF
--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingInterceptors.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingInterceptors.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.uber.jaeger.httpclient;
 
 import io.opentracing.Tracer;

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/ConfigurationTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/ConfigurationTest.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.uber.jaeger.dropwizard;
 
 import org.junit.Test;

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
@@ -167,7 +167,7 @@ public final class ZipkinSender implements Sender {
   // serviceName/host is needed on annotations so zipkin can query
   // see https://github.com/uber/jaeger-client-java/pull/75 for more info
   Span backFillHostOnAnnotations(Span span) {
-    Endpoint host = getLocalComponentEndpoint(span);
+    Endpoint host = getServiceEndpoint(span);
 
     if (host != null) {
       for (BinaryAnnotation binaryAnnotation : span.getBinary_annotations()) {
@@ -186,10 +186,10 @@ public final class ZipkinSender implements Sender {
     return span;
   }
 
-  private Endpoint getLocalComponentEndpoint(Span span) {
-    for (BinaryAnnotation binaryAnnotation : span.getBinary_annotations()) {
-      if (Constants.CORE_ANNOTATIONS.contains(binaryAnnotation.getKey()) && binaryAnnotation.isSetHost()) {
-        return binaryAnnotation.getHost();
+  private Endpoint getServiceEndpoint(Span span) {
+    for (Annotation annotation : span.getAnnotations()) {
+      if (Constants.CORE_ANNOTATIONS.contains(annotation.getValue()) && annotation.isSetHost()) {
+        return annotation.getHost();
       }
     }
 

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
@@ -21,7 +21,7 @@
  */
 package com.uber.jaeger.senders.zipkin;
 
-import com.twitter.zipkin.thriftjava.Span;
+import com.twitter.zipkin.thriftjava.*;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.senders.Sender;
 
@@ -94,7 +94,7 @@ public final class ZipkinSender implements Sender {
    */
   @Override
   public int append(Span span) throws SenderException {
-    byte[] next = encoder.encode(span);
+    byte[] next = encoder.encode(backFillHostOnAnnotations(span));
     int messageSizeOfNextSpan = delegate.messageSizeInBytes(Collections.singletonList(next));
     // don't enqueue something larger than we can drain
     if (Integer.compare(messageSizeOfNextSpan, delegate.messageMaxBytes()) > 0) {
@@ -160,5 +160,32 @@ public final class ZipkinSender implements Sender {
       throw new SenderException("Failed to close " + delegate, e, n);
     }
     return n;
+  }
+
+  // serviceName/host is needed on annotations so zipkin can query
+  // see https://github.com/uber/jaeger-client-java/pull/75 for more info
+  Span backFillHostOnAnnotations(Span span) {
+    Endpoint host = null;
+    for (BinaryAnnotation binaryAnnotation : span.getBinary_annotations()) {
+      if (zipkincoreConstants.LOCAL_COMPONENT.equals(binaryAnnotation.getKey())) {
+        host = binaryAnnotation.getHost();
+      }
+    }
+
+    if (host != null) {
+      for (BinaryAnnotation binaryAnnotation : span.getBinary_annotations()) {
+        if (!binaryAnnotation.isSetHost()) {
+          binaryAnnotation.setHost(host);
+        }
+      }
+
+      for (Annotation annotation : span.getAnnotations()) {
+        if (!annotation.isSetHost()) {
+          annotation.setHost(host);
+        }
+      }
+    }
+
+    return span;
   }
 }


### PR DESCRIPTION
I found this while trying to figure out why zipkin's annotation queries weren't working. It seems that zipkin uses the serviceName in the endpoint as a search parameter: https://github.com/openzipkin/zipkin/blob/master/zipkin-storage/elasticsearch/src/main/java/zipkin/storage/elasticsearch/ElasticsearchSpanStore.java#L115 

This is from https://github.com/openzipkin/zipkin/pull/1292

So I changed the zipkin span converter to always send along the host on all the binary and non binary annotations. After that it, everything works quite swimmingly. 