### PR TITLE
Publish a shadow jar with thrift 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ For e.g, to depend on the core jaeger library, you'd include the following
 </dependency>
 ```
 
+###Thrift version conflicts
+Jaeger client uses `org.apache.thrift:libthrift:0.9.2`. If your project depends on a different
+version of `libthrift`, it is recommended that you use the shaded `jaeger-thrift` jar we publish
+which packages it's own `libthrift`.
+
+To depend on the shaded jar, add the following to your maven build.
+Note that this is only supported for a jaeger version >= 0.15.0
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.uber.jaeger</groupId>
+      <artifactId>jaeger-thrift</artifactId>
+      <classifier>thrift92</classifier>
+      <version>$jaegerVersion</version>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+
 ## In-process Context Propagation
 `jaeger-context` defines
 [ThreadLocalTraceContext](./jaeger-context/src/main/java/com/uber/jaeger/context)

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'org.jruyi.thrift'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 //This is in a separate subproject so that we can use 
 //standard javac instead of the error prone compiler
@@ -38,6 +39,18 @@ sourceSets {
 jar {
     from sourceSets.main.output
     manifest {
-        attributes('Implementation-Title': 'jaeger-generated', 'Implementation-Version': project.version)
+        attributes('Implementation-Title': 'jaeger-thrift', 'Implementation-Version': project.version)
+    }
+}
+
+shadowJar {
+    baseName = 'jaeger-thrift'
+    relocate 'org.apache.thrift', 'org.shadow.apache.thrift92'
+    classifier 'thrift92'
+}
+
+artifacts {
+    archives(shadowJar.archivePath) {
+        builtBy shadowJar
     }
 }


### PR DESCRIPTION
- publishes an additional jar that packages `org.apache.thrift:libthrift:0.9.2` under the classifier `thrift92`
- relocates `org.apache.thrift` to `org.shadow.apache.thrift92` in the shaded jar

Fixes https://github.com/uber/jaeger-client-java/issues/80