### PR TITLE
Fix code coverage generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "org.jruyi.thrift" version "0.3.1"
     id "jacoco"
-    id "com.github.kt3k.coveralls" version "2.5.0"
+    id "com.github.kt3k.coveralls" version "2.7.1"
     id "com.github.hierynomus.license" version "0.12.1"
     id 'com.github.sherter.google-java-format' version '0.3.2'
     id "com.github.johnrengelman.shadow" version "1.2.3"

--- a/jaeger-crossdock/rules.mk
+++ b/jaeger-crossdock/rules.mk
@@ -17,7 +17,7 @@ crossdock-fresh: gradle-compile
 	docker-compose -f $(XDOCK_YAML) run crossdock
 
 gradle-compile:
-	./gradlew clean :jaeger-crossdock:shadowJar
+	./gradlew :jaeger-crossdock:shadowJar
 
 .PHONY: crossdock-logs
 crossdock-logs:


### PR DESCRIPTION
- `./gradlew clean` runs after tests have run, thus not providing the
  `jacocoTestReport` task with data to generate the test report from.