### PR TITLE
Automatically add span names for jersey instrumentation

### DIFF
--- a/jaeger-dropwizard/build.gradle
+++ b/jaeger-dropwizard/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile group: 'io.dropwizard', name: 'dropwizard-hibernate', version: '0.9.1'
 
     testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
+    testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
 }

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
@@ -43,7 +43,7 @@ public class JaegerFeature implements Feature {
 
     switch (featureContext.getConfiguration().getRuntimeType()) {
       case SERVER:
-        featureContext.register(TracingUtils.serverFilter(tracer));
+        featureContext.register(new JerseyServerFilter(tracer, com.uber.jaeger.context.TracingUtils.getTraceContext()));
         break;
       case CLIENT:
         featureContext.register(TracingUtils.clientFilter(tracer));

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -75,12 +75,8 @@ public class JerseyServerFilter extends ServerFilter {
           List<UriTemplate> templates = uriRoutingContext.getMatchedTemplates();
           String operationName = "";
           for (UriTemplate uriTemplate : templates) {
-            try {
-              String template = (String) normalizedTemplate.get(uriTemplate);
-              operationName = template + operationName;
-            } catch (IllegalAccessException e) {
-              log.error("No access to %s", normalizedTemplate, e);
-            }
+            String template = (String) normalizedTemplate.get(uriTemplate);
+            operationName = template + operationName;
           }
           return String.format("%s - %s", containerRequest.getMethod(), operationName);
         }

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -82,9 +82,7 @@ public class JerseyServerFilter extends ServerFilter {
               log.error("No access to %s", normalizedTemplate, e);
             }
           }
-          String s = String.format("%s - %s", containerRequest.getMethod(), operationName);
-          System.out.println(s);
-          return s;
+          return String.format("%s - %s", containerRequest.getMethod(), operationName);
         }
       }
     } catch (Exception e) {

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -99,11 +99,9 @@ public class JerseyServerFilter extends ServerFilter {
    * @return the operation name
    */
   private String getResourceMethodOperationName(ContainerRequestContext containerRequestContext) {
-    String operationName;Method method = resourceInfo.getResourceMethod();
-    operationName =
-        String.format("%s - %s:%s", containerRequestContext.getMethod(),
-                      method.getDeclaringClass().getCanonicalName(), method.getName());
-    return operationName;
+    Method method = resourceInfo.getResourceMethod();
+    return String.format("%s - %s:%s", containerRequestContext.getMethod(),
+                         method.getDeclaringClass().getCanonicalName(), method.getName());
   }
 
   /**

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.jaeger.dropwizard;
+
+import com.uber.jaeger.context.TraceContext;
+import com.uber.jaeger.filters.jaxrs2.ServerFilter;
+import io.opentracing.Tracer;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
+import org.glassfish.jersey.uri.UriTemplate;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A {@link ServerFilter} that provides a Jersey specific {@link #getOperationName} implementation.
+ * When using this Filter with Jersey, the full @Path template hierarchy is used as the
+ * operation name.
+ */
+@Slf4j
+public class JerseyServerFilter extends ServerFilter {
+
+  private Field normalizedTemplate;
+
+  public JerseyServerFilter(Tracer tracer,
+                            TraceContext traceContext) {
+    super(tracer, traceContext);
+
+    try {
+      normalizedTemplate = UriTemplate.class.getDeclaredField("normalizedTemplate");
+      normalizedTemplate.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      //TODO: Add metrics for failure counts
+      log.error("Cannot access the normalizedTemplate field from UriTemplate. "
+                    + "Path operation name for tracing will be disabled.", e);
+    }
+  }
+
+  /**
+   * Retrieves an operation name that contains the http method and value of the
+   * {@link Path} used by a Jersey server implementation.
+   * @return the operation name
+   */
+  @Override
+  protected String getOperationName(ContainerRequestContext containerRequestContext) {
+    try {
+      if (normalizedTemplate != null && containerRequestContext instanceof ContainerRequest) {
+        ContainerRequest containerRequest = (ContainerRequest) containerRequestContext;
+        ExtendedUriInfo uriInfo = containerRequest.getUriInfo();
+        if (uriInfo instanceof UriRoutingContext) {
+          UriRoutingContext uriRoutingContext = (UriRoutingContext) uriInfo;
+          List<UriTemplate> templates = uriRoutingContext.getMatchedTemplates();
+          String operationName = "";
+          for (UriTemplate uriTemplate : templates) {
+            try {
+              String template = (String) normalizedTemplate.get(uriTemplate);
+              operationName = template + operationName;
+            } catch (IllegalAccessException e) {
+              log.error("No access to %s", normalizedTemplate, e);
+            }
+          }
+          String s = String.format("%s - %s", containerRequest.getMethod(), operationName);
+          System.out.println(s);
+          return s;
+        }
+      }
+    } catch (Exception e) {
+      log.error("Unable to get operation name", e);
+    }
+    return containerRequestContext.getMethod();
+  }
+}

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.ext.Provider;
@@ -52,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Provider
+@Singleton
 public class JerseyServerFilter extends ServerFilter {
 
   private Map<CacheKey, String> methodToPathCache = new ConcurrentHashMap<>();

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -102,7 +102,7 @@ public class JerseyServerFilter extends ServerFilter {
    */
   private String getResourceMethodOperationName(ContainerRequestContext containerRequestContext) {
     Method method = resourceInfo.getResourceMethod();
-    return String.format("%s - %s:%s", containerRequestContext.getMethod(),
+    return String.format("%s:%s:%s", containerRequestContext.getMethod(),
                          method.getDeclaringClass().getCanonicalName(), method.getName());
   }
 
@@ -125,7 +125,7 @@ public class JerseyServerFilter extends ServerFilter {
             String template = (String) normalizedTemplate.get(uriTemplate);
             path = template + path;
           }
-          operationName = String.format("%s - %s", containerRequest.getMethod(), path);
+          operationName = String.format("%s:%s", containerRequest.getMethod(), path);
         }
       }
     } catch (Exception e) {

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -89,7 +89,7 @@ public class JerseyServerFilterTest extends JerseyTest {
     Response response = target("hello/world/middle-earth").request().get();
     assertEquals(200, response.getStatus());
     Span span = reporter.getSpans().get(0);
-    assertEquals("GET - /hello/world/{worldId}", span.getOperationName());
+    assertEquals("GET:/hello/world/{worldId}", span.getOperationName());
     assertCache("getHello");
   }
 
@@ -98,7 +98,7 @@ public class JerseyServerFilterTest extends JerseyTest {
     Response response = target("stormlord/").request().get();
     assertEquals(200, response.getStatus());
     Span span = reporter.getSpans().get(0);
-    assertEquals("GET - /stormlord", span.getOperationName());
+    assertEquals("GET:/stormlord", span.getOperationName());
     assertCache("nakedGet");
   }
 
@@ -115,8 +115,8 @@ public class JerseyServerFilterTest extends JerseyTest {
       valueSet.add(entry.getValue());
     }
 
-    assertTrue(valueSet.contains("GET - /stormlord"));
-    assertTrue(valueSet.contains("GET - /hello/world/{worldId}"));
+    assertTrue(valueSet.contains("GET:/stormlord"));
+    assertTrue(valueSet.contains("GET:/hello/world/{worldId}"));
   }
 
   private void assertCache(String methodName) {

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -41,6 +41,7 @@ public class JerseyServerFilterTest extends JerseyTest {
 
   private InMemoryReporter reporter;
 
+  @Override
   protected Application configure() {
     Configuration config = new Configuration("world service", false,
                                              new com.uber.jaeger.Configuration.SamplerConfiguration(ConstSampler.TYPE,

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -90,7 +90,6 @@ public class JerseyServerFilterTest extends JerseyTest {
     assertCache("getHello");
   }
 
-
   @Test
   public void testOperationNameWithNakedGet() throws Exception {
     Response response = target("stormlord/").request().get();

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.jaeger.dropwizard;
+
+import static junit.framework.Assert.assertEquals;
+
+import com.uber.jaeger.Span;
+import com.uber.jaeger.reporters.InMemoryReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+public class JerseyServerFilterTest extends JerseyTest {
+
+  private InMemoryReporter reporter;
+
+  protected Application configure() {
+    Configuration config = new Configuration("world service", false,
+                                             new com.uber.jaeger.Configuration.SamplerConfiguration(ConstSampler.TYPE,
+                                                                                                    1),
+                                             null);
+    reporter = new InMemoryReporter();
+    com.uber.jaeger.Tracer tracer = (com.uber.jaeger.Tracer) config.getTracer();
+    try {
+      Field reporter = com.uber.jaeger.Tracer.class.getDeclaredField("reporter");
+      reporter.setAccessible(true);
+      reporter.set(tracer, this.reporter);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+
+    ResourceConfig resourceConfig = new ResourceConfig(HelloResource.class, StormlordResource.class);
+    resourceConfig.register(new JaegerFeature(config));
+    return resourceConfig;
+  }
+
+  @Path("hello")
+  public static class HelloResource {
+    @GET
+    @Path("world/{worldId}")
+    public String getHello(@QueryParam("worldId") String val) {
+      return "Hello " + val;
+    }
+  }
+
+  @Path("stormlord")
+  public static class StormlordResource {
+    @GET
+    public String nakedGet() {
+      return "Gwaihir";
+    }
+  }
+
+  @Test
+  public void testOperationNameSuccess() throws Exception {
+    Response response = target("hello/world/middle-earth").request().get();
+    assertEquals(200, response.getStatus());
+    Span span = reporter.getSpans().get(0);
+    assertEquals("GET - /hello/world/{worldId}", span.getOperationName());
+  }
+
+  @Test
+  public void testOperationNameWithNakedGet() throws Exception {
+    Response response = target("stormlord/").request().get();
+    assertEquals(200, response.getStatus());
+    Span span = reporter.getSpans().get(0);
+    assertEquals("GET - /stormlord", span.getOperationName());
+  }
+
+}

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -35,6 +35,8 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
@@ -44,6 +46,9 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
   private final TraceContext traceContext;
   private final Logger logger = LoggerFactory.getLogger(ServerFilter.class);
 
+  @Context
+  protected ResourceInfo resourceInfo;
+
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this.tracer = tracer;
     this.traceContext = traceContext;
@@ -51,6 +56,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
 
   @Override
   public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+    //TODO: Add a @DisableTracing annotation and use the resourceInfo to check if it's applied
     try {
       Tracer.SpanBuilder builder =
           tracer

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -54,7 +54,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
     try {
       Tracer.SpanBuilder builder =
           tracer
-              .buildSpan(containerRequestContext.getMethod())
+              .buildSpan(getOperationName(containerRequestContext))
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               //TODO(oibe) figure out how to get remote addr from grizzly HttpServletRequest
               .withTag(
@@ -104,5 +104,14 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
     } catch (Exception e) {
       logger.error("Server Filter Response:", e);
     }
+  }
+
+  /**
+   * An operation name to use for the span being reported. Uses the http method name by default.
+   * @param containerRequestContext A class that holds request specific information
+   * @return the operation name
+   */
+  protected String getOperationName(ContainerRequestContext containerRequestContext) {
+    return containerRequestContext.getMethod();
   }
 }


### PR DESCRIPTION
For the dropwizard jaeger feature implementation, generate the
default operation name for a given span based on the @Path()
annotations set on the calling resource.