### PR TITLE
Make Tracer#isRPCServer robust

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -158,7 +158,8 @@ public class Tracer implements io.opentracing.Tracer {
     sampler.close();
   }
 
-  private class SpanBuilder implements io.opentracing.Tracer.SpanBuilder {
+  //Visible for testing
+  class SpanBuilder implements io.opentracing.Tracer.SpanBuilder {
 
     private String operationName = null;
     private long startTimeMicroseconds;
@@ -259,7 +260,8 @@ public class Tracer implements io.opentracing.Tracer {
           null);
     }
 
-    private boolean isRPCServer() {
+    //Visible for testing
+    boolean isRPCServer() {
       return Tags.SPAN_KIND_SERVER.equals(tags.get(Tags.SPAN_KIND.getKey()));
     }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -260,7 +260,7 @@ public class Tracer implements io.opentracing.Tracer {
     }
 
     private boolean isRPCServer() {
-      return tags.get(Tags.SPAN_KIND.getKey()) == Tags.SPAN_KIND_SERVER;
+      return Tags.SPAN_KIND_SERVER.equals(tags.get(Tags.SPAN_KIND.getKey()));
     }
 
     @Override

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -22,6 +22,8 @@
 package com.uber.jaeger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -133,6 +135,22 @@ public class TracerTest {
   @Test(expected = IllegalArgumentException.class)
   public void testServiceNameNotEmptyNull() {
     new Tracer.Builder("  ", new InMemoryReporter(), new ConstSampler(true));
+  }
+
+  @Test
+  public void testBuilderIsServerRPC() {
+    Tracer.SpanBuilder spanBuilder = (Tracer.SpanBuilder) tracer.buildSpan("ndnd");
+    spanBuilder.withTag(Tags.SPAN_KIND.getKey(), "server");
+
+    assertTrue(spanBuilder.isRPCServer());
+  }
+
+  @Test
+  public void testBuilderIsNotServerRPC() {
+    Tracer.SpanBuilder spanBuilder = (Tracer.SpanBuilder) tracer.buildSpan("Lrrr");
+    spanBuilder.withTag(Tags.SPAN_KIND.getKey(), "peachy");
+
+    assertFalse(spanBuilder.isRPCServer());
   }
 
   @Test


### PR DESCRIPTION
- Instead of comparing that the specific Tags.SPAN_KIND_SERVER object
  is used, simply check whether the field contains "server"