### PR TITLE
Fix client/server span classification

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -75,7 +75,9 @@ public class Span implements io.opentracing.Span {
   }
 
   public long getDuration() {
-    return durationMicroseconds;
+    synchronized (this) {
+      return durationMicroseconds;
+    }
   }
 
   public Tracer getTracer() {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -185,17 +185,17 @@ public class Span implements io.opentracing.Span {
   }
 
   @Override
-  public Span setTag(String key, String value) {
+  public synchronized Span setTag(String key, String value) {
     return setTagAsObject(key, value);
   }
 
   @Override
-  public Span setTag(String key, boolean value) {
+  public synchronized Span setTag(String key, boolean value) {
     return setTagAsObject(key, value);
   }
 
   @Override
-  public Span setTag(String key, Number value) {
+  public synchronized Span setTag(String key, Number value) {
     return setTagAsObject(key, value);
   }
 
@@ -241,7 +241,6 @@ public class Span implements io.opentracing.Span {
    * See {@link #handleSpecialTag(String, Object)}
    */
   private Span setTagAsObject(String key, Object value) {
-    synchronized (this) {
       if (key.equals(Tags.SAMPLING_PRIORITY.getKey()) && (value instanceof Number)) {
         int priority = ((Number) value).intValue();
         byte newFlags;
@@ -259,7 +258,6 @@ public class Span implements io.opentracing.Span {
           tags.put(key, value);
         }
       }
-    }
 
     return this;
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -35,11 +35,11 @@ public class Span implements io.opentracing.Span {
   private final long startTimeMicroseconds;
   private final long startTimeNanoTicks;
   private final boolean computeDurationViaNanoTicks;
+  private final Map<String, Object> tags;
   private long durationMicroseconds; // span durationMicroseconds
   private String operationName;
   private SpanContext context;
   private Endpoint peer;
-  private Map<String, Object> tags;
   private List<LogData> logs;
   private String localComponent;
   private boolean isClient;
@@ -59,7 +59,11 @@ public class Span implements io.opentracing.Span {
     this.startTimeMicroseconds = startTimeMicroseconds;
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
-    sanitizeAndSetTags(tags);
+    this.tags = new HashMap<>();
+
+    for (Map.Entry<String, Object> tag : tags.entrySet()) {
+      setTagAsObject(tag.getKey(), tag.getValue());
+    }
   }
 
   public String getLocalComponent() {
@@ -71,9 +75,7 @@ public class Span implements io.opentracing.Span {
   }
 
   public long getDuration() {
-    synchronized (this) {
-      return durationMicroseconds;
-    }
+    return durationMicroseconds;
   }
 
   public Tracer getTracer() {
@@ -260,16 +262,6 @@ public class Span implements io.opentracing.Span {
       }
 
     return this;
-  }
-
-  /**
-   * uses {@link #setTagAsObject} to only insert tags that don't have special significance
-   */
-  private void sanitizeAndSetTags(Map<String, Object> tags) {
-    this.tags = new HashMap<>();
-    for (Map.Entry<String, Object> tag : tags.entrySet()) {
-      setTagAsObject(tag.getKey(), tag.getValue());
-    }
   }
 
   @Override

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -62,16 +62,16 @@ public class TracerTest {
   @Test
   public void testBuildSpan() {
     String expectedOperation = "fry";
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan(expectedOperation).start();
+    Span span = (Span) tracer.buildSpan(expectedOperation).start();
 
     assertEquals(expectedOperation, span.getOperationName());
   }
 
   @Test
   public void testBuildServerSpan() {
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan("flexo")
-                                             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-                                             .start();
+    Span span = (Span) tracer.buildSpan("flexo")
+                             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                             .start();
 
     assertTrue(span.isRPC());
     assertFalse(span.isRPCClient());
@@ -79,9 +79,9 @@ public class TracerTest {
 
   @Test
   public void testBuildClientSpan() {
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan("bender")
-                                           .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                                           .start();
+    Span span = (Span) tracer.buildSpan("bender")
+                             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                             .start();
 
     assertTrue(span.isRPC());
     assertTrue(span.isRPCClient());

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -70,8 +70,8 @@ public class TracerTest {
   @Test
   public void testBuildServerSpan() {
     Span span = (com.uber.jaeger.Span) tracer.buildSpan("flexo")
-                                             .withTag(Tags.SPAN_KIND.getKey(),
-                                                      Tags.SPAN_KIND_SERVER).start();
+                                             .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                                             .start();
 
     assertTrue(span.isRPC());
     assertFalse(span.isRPCClient());
@@ -80,11 +80,11 @@ public class TracerTest {
   @Test
   public void testBuildClientSpan() {
     Span span = (com.uber.jaeger.Span) tracer.buildSpan("bender")
-                                           .withTag(Tags.SPAN_KIND.getKey(),
-                                                    Tags.SPAN_KIND_SERVER).start();
+                                           .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                                           .start();
 
     assertTrue(span.isRPC());
-    assertFalse(span.isRPCClient());
+    assertTrue(span.isRPCClient());
   }
 
   @Test

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -22,6 +22,8 @@
 package com.uber.jaeger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -63,6 +65,26 @@ public class TracerTest {
     Span span = (com.uber.jaeger.Span) tracer.buildSpan(expectedOperation).start();
 
     assertEquals(expectedOperation, span.getOperationName());
+  }
+
+  @Test
+  public void testBuildServerSpan() {
+    Span span = (com.uber.jaeger.Span) tracer.buildSpan("flexo")
+                                             .withTag(Tags.SPAN_KIND.getKey(),
+                                                      Tags.SPAN_KIND_SERVER).start();
+
+    assertTrue(span.isRPC());
+    assertFalse(span.isRPCClient());
+  }
+
+  @Test
+  public void testBuildClientSpan() {
+    Span span = (com.uber.jaeger.Span) tracer.buildSpan("bender")
+                                           .withTag(Tags.SPAN_KIND.getKey(),
+                                                    Tags.SPAN_KIND_SERVER).start();
+
+    assertTrue(span.isRPC());
+    assertFalse(span.isRPCClient());
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
@@ -22,6 +22,7 @@
 package com.uber.jaeger.filters.jaxrs2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -93,10 +94,11 @@ public class ServerFilterTest {
 
     List<Span> spans = reporter.getSpans();
     assertEquals(1, spans.size());
-    Map<String, Object> tags = spans.get(0).getTags();
+    Span span = spans.get(0);
+    Map<String, Object> tags = span.getTags();
 
-    assertEquals("server", tags.get(Tags.SPAN_KIND.getKey()));
-    assertEquals(source, tags.get(Tags.PEER_SERVICE.getKey()));
+    assertTrue(span.isRPC() && !span.isRPCClient());
+    assertEquals(source, span.getPeer().getService_name());
     assertEquals(uri.toString(), tags.get(Tags.HTTP_URL.getKey()));
     assertEquals("localhost", tags.get(Tags.PEER_HOSTNAME.getKey()));
   }


### PR DESCRIPTION
The `Span` object has custom logic to set `Span#isRpc` and `Span#isClient` based
on the tags passed into `Span#setTag`.
Creating a `Span` using `SpanBuilder` bypasses this logic causing `Span#isRPC` to be
false. This causes ThriftSpanConverter to use `lc` annotations instead of `sr/ss`

This commit sanitizes input from `SpanBuilder` so that setting tags on the
`SpanBuilder` results in the same behavior as setting a tag on the `Span`.