### PR TITLE
Define json models for SamplingStrategyResponse and use them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ ext.guavaVersion = '18.0'
 ext.apacheThriftVersion = '0.9.2'
 ext.jerseyVersion = '2.22.2'
 ext.slf4jVersion = '1.7.16'
-ext.jacksonVersion = '2.7.4'
 ext.apacheHttpComponentsVersion = '4.1.2'
 ext.gsonVersion = '2.8.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ ext.jerseyVersion = '2.22.2'
 ext.slf4jVersion = '1.7.16'
 ext.jacksonVersion = '2.7.4'
 ext.apacheHttpComponentsVersion = '4.1.2'
+ext.gsonVersion = '2.8.0'
 
 ext.junitVersion = '4.12'
 ext.mockitoVersion = '2.0.2-beta'

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -6,7 +6,7 @@ description = 'Core library for jaeger-client'
 dependencies {
     compile project(':jaeger-thrift')
     compile group: 'io.opentracing', name: 'opentracing-api', version: opentracingVersion
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
 
     // Testing frameworks

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -6,7 +6,7 @@ description = 'Core library for jaeger-client'
 dependencies {
     compile project(':jaeger-thrift')
     compile group: 'io.opentracing', name: 'opentracing-api', version: opentracingVersion
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'
+    compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
 
     // Testing frameworks

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -24,9 +24,10 @@ package com.uber.jaeger.samplers;
 import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
 import com.uber.jaeger.exceptions.UnknownSamplingStrategyException;
 import com.uber.jaeger.metrics.Metrics;
-import com.uber.jaeger.thrift.sampling_manager.ProbabilisticSamplingStrategy;
-import com.uber.jaeger.thrift.sampling_manager.RateLimitingSamplingStrategy;
-import com.uber.jaeger.thrift.sampling_manager.SamplingStrategyResponse;
+import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
+import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
+import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import com.uber.jaeger.samplers.http.SamplingStrategyType;
 
 import java.util.Map;
 import java.util.Timer;
@@ -104,12 +105,12 @@ public class RemoteControlledSampler implements Sampler {
 
   private Sampler extractSampler(SamplingStrategyResponse response)
       throws UnknownSamplingStrategyException {
-    if (response.isSetProbabilisticSampling()) {
+    if (SamplingStrategyType.PROBABILISTIC.equals(response.getStrategyType())) {
       ProbabilisticSamplingStrategy strategy = response.getProbabilisticSampling();
       return new ProbabilisticSampler(strategy.getSamplingRate());
     }
 
-    if (response.isSetRateLimitingSampling()) {
+    if (SamplingStrategyType.RATE_LIMITING.equals(response.getStrategyType())) {
       RateLimitingSamplingStrategy strategy = response.getRateLimitingSampling();
       return new RateLimitingSampler(strategy.getMaxTracesPerSecond());
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/ProbabilisticSamplingStrategy.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/ProbabilisticSamplingStrategy.java
@@ -19,12 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.samplers;
+package com.uber.jaeger.samplers.http;
 
-import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
-import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import lombok.Value;
 
-public interface SamplingManager {
-  SamplingStrategyResponse getSamplingStrategy(String serviceName)
-      throws SamplingStrategyErrorException;
+@Value
+public class ProbabilisticSamplingStrategy {
+  double samplingRate;
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/RateLimitingSamplingStrategy.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/RateLimitingSamplingStrategy.java
@@ -19,12 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.samplers;
+package com.uber.jaeger.samplers.http;
 
-import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
-import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import lombok.Value;
 
-public interface SamplingManager {
-  SamplingStrategyResponse getSamplingStrategy(String serviceName)
-      throws SamplingStrategyErrorException;
+@Value
+public class RateLimitingSamplingStrategy {
+  int maxTracesPerSecond;
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyResponse.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyResponse.java
@@ -19,12 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.samplers;
+package com.uber.jaeger.samplers.http;
 
-import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
-import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import lombok.Value;
 
-public interface SamplingManager {
-  SamplingStrategyResponse getSamplingStrategy(String serviceName)
-      throws SamplingStrategyErrorException;
+@Value
+public class SamplingStrategyResponse {
+  SamplingStrategyType strategyType;
+  ProbabilisticSamplingStrategy probabilisticSampling;
+  RateLimitingSamplingStrategy rateLimitingSampling;
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyType.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyType.java
@@ -19,12 +19,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.samplers;
+package com.uber.jaeger.samplers.http;
 
-import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
-import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import com.google.gson.annotations.SerializedName;
 
-public interface SamplingManager {
-  SamplingStrategyResponse getSamplingStrategy(String serviceName)
-      throws SamplingStrategyErrorException;
+import lombok.Getter;
+
+public enum SamplingStrategyType {
+  @SerializedName("0")
+  PROBABILISTIC (0),
+
+  @SerializedName("1")
+  RATE_LIMITING (1);
+
+  @Getter
+  private final int value;
+
+  SamplingStrategyType(int value) {
+    this.value = value;
+  }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/HTTPSamplingManagerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/HTTPSamplingManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.jaeger.samplers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
+import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
+import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import com.uber.jaeger.samplers.http.SamplingStrategyType;
+import org.junit.Test;
+
+public class HTTPSamplingManagerTest {
+
+  HTTPSamplingManager undertest = new HTTPSamplingManager(null);
+
+  @Test
+  public void testParseProbabilisticSampling() {
+    SamplingStrategyResponse response =
+        undertest.parseJson(
+            "{\"strategyType\":0,"
+                + "\"probabilisticSampling\":{\"samplingRate\":0.01},"
+                + "\"rateLimitingSampling\":null}");
+    assertEquals(SamplingStrategyType.PROBABILISTIC, response.getStrategyType());
+    assertEquals(new ProbabilisticSamplingStrategy(0.01), response.getProbabilisticSampling());
+    assertNull(response.getRateLimitingSampling());
+  }
+
+  @Test
+  public void testParseRateLimitingSampling() {
+    SamplingStrategyResponse response =
+        undertest.parseJson(
+            "{\"strategyType\":1,"
+                + "\"probabilisticSampling\":null,"
+                + "\"rateLimitingSampling\":{\"maxTracesPerSecond\":1}}");
+    assertEquals(SamplingStrategyType.RATE_LIMITING, response.getStrategyType());
+    assertEquals(new RateLimitingSamplingStrategy(1), response.getRateLimitingSampling());
+    assertNull(response.getProbabilisticSampling());
+  }
+
+}

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
@@ -21,18 +21,19 @@
  */
 package com.uber.jaeger.samplers;
 
-import com.uber.jaeger.metrics.InMemoryStatsReporter;
-import com.uber.jaeger.metrics.Metrics;
-import com.uber.jaeger.thrift.sampling_manager.SamplingStrategyResponse;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.uber.jaeger.metrics.InMemoryStatsReporter;
+import com.uber.jaeger.metrics.Metrics;
+import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import com.uber.jaeger.samplers.http.SamplingStrategyType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RemoteControlledSamplerTest {
   MockAgent agent;
@@ -72,9 +73,7 @@ public class RemoteControlledSamplerTest {
 
   private RemoteControlledSampler makeSamplerWith(Sampler underlyingSampler) throws Exception {
     HTTPSamplingManager manager = mock(HTTPSamplingManager.class);
-    SamplingStrategyResponse response = mock(SamplingStrategyResponse.class);
-    when(response.isSetProbabilisticSampling()).thenReturn(false);
-    when(response.isSetRateLimitingSampling()).thenReturn(false);
+    SamplingStrategyResponse response = new SamplingStrategyResponse(SamplingStrategyType.PROBABILISTIC, null, null);
     when(manager.getSamplingStrategy("jaeger")).thenReturn(response);
     return new RemoteControlledSampler("jaeger", manager, underlyingSampler, metrics);
   }

--- a/jaeger-jaxrs2/build.gradle
+++ b/jaeger-jaxrs2/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     testCompile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
     testCompile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
     testCompile group: 'org.glassfish.jersey.media', name: 'jersey-media-moxy', version: jerseyVersion
-    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-all', version: mockitoVersion
 }


### PR DESCRIPTION
- Use our own json models instead of depending on thrift generated classes.
  This will help up when we move to manual thrift generation
- Use Google's gson instead of jackson-databind
- Add tests for HttpSamplingManager