### PR TITLE
Refactor Sampler interface

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -230,7 +230,8 @@ public class Tracer implements io.opentracing.Tracer {
         flags |= SpanContext.flagSampled | SpanContext.flagDebug;
         tags.put(Constants.DEBUG_ID_HEADER_KEY, debugID);
         metrics.traceStartedSampled.inc(1);
-      } else if (sampler.isSampled(id)) {
+        //TODO(prithvi): Don't assume operationName is set on creation
+      } else if (sampler.isSampled(operationName, id)) {
         flags |= SpanContext.flagSampled;
         tags.putAll(sampler.getTags());
         metrics.traceStartedSampled.inc(1);

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -233,7 +233,7 @@ public class Tracer implements io.opentracing.Tracer {
         metrics.traceStartedSampled.inc(1);
       } else {
         //TODO(prithvi): Don't assume operationName is set on creation
-        SamplingStatus samplingStatus = sampler.getSamplingStatus(operationName, id);
+        SamplingStatus samplingStatus = sampler.sample(operationName, id);
         if (samplingStatus.isSampled()) {
           flags |= SpanContext.flagSampled;
           tags.putAll(samplingStatus.getTags());

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -31,6 +31,7 @@ import com.uber.jaeger.propagation.Injector;
 import com.uber.jaeger.propagation.TextMapCodec;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.Sampler;
+import com.uber.jaeger.samplers.SamplingStatus;
 import com.uber.jaeger.utils.Clock;
 import com.uber.jaeger.utils.SystemClock;
 import com.uber.jaeger.utils.Utils;
@@ -230,14 +231,18 @@ public class Tracer implements io.opentracing.Tracer {
         flags |= SpanContext.flagSampled | SpanContext.flagDebug;
         tags.put(Constants.DEBUG_ID_HEADER_KEY, debugID);
         metrics.traceStartedSampled.inc(1);
-        //TODO(prithvi): Don't assume operationName is set on creation
-      } else if (sampler.isSampled(operationName, id)) {
-        flags |= SpanContext.flagSampled;
-        tags.putAll(sampler.getTags());
-        metrics.traceStartedSampled.inc(1);
       } else {
-        metrics.traceStartedNotSampled.inc(1);
+        //TODO(prithvi): Don't assume operationName is set on creation
+        SamplingStatus samplingStatus = sampler.getSamplingStatus(operationName, id);
+        if (samplingStatus.isSampled()) {
+          flags |= SpanContext.flagSampled;
+          tags.putAll(samplingStatus.getTags());
+          metrics.traceStartedSampled.inc(1);
+        } else {
+          metrics.traceStartedNotSampled.inc(1);
+        }
       }
+
       return new SpanContext(id, id, 0, flags);
     }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -51,13 +51,8 @@ public class ConstSampler implements Sampler {
    * @return A boolean that says whether to sample.
    */
   @Override
-  public SamplingStatus getSamplingStatus(String operation, long id) {
+  public SamplingStatus sample(String operation, long id) {
     return SamplingStatus.of(decision, tags);
-  }
-
-  // Visible for testing
-  Map<String, Object> getTags() {
-    return this.tags;
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -51,8 +51,8 @@ public class ConstSampler implements Sampler {
    * @return A boolean that says whether to sample.
    */
   @Override
-  public boolean isSampled(String operation, long id) {
-    return decision;
+  public SamplingStatus getSamplingStatus(String operation, long id) {
+    return SamplingStatus.of(decision, tags);
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -55,8 +55,8 @@ public class ConstSampler implements Sampler {
     return SamplingStatus.of(decision, tags);
   }
 
-  @Override
-  public Map<String, Object> getTags() {
+  // Visible for testing
+  Map<String, Object> getTags() {
     return this.tags;
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -51,7 +51,7 @@ public class ConstSampler implements Sampler {
    * @return A boolean that says whether to sample.
    */
   @Override
-  public boolean isSampled(long id) {
+  public boolean isSampled(String operation, long id) {
     return decision;
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -61,11 +61,12 @@ public class ProbabilisticSampler implements Sampler {
    * @return A boolean that says wheter or not to sample.
    */
   @Override
-  public boolean isSampled(String operation, long id) {
+  public SamplingStatus getSamplingStatus(String operation, long id) {
     if (id > 0) {
-      return id <= this.positiveSamplingBoundary;
+      return SamplingStatus.of(id <= this.positiveSamplingBoundary, tags);
+    } else {
+      return SamplingStatus.of(id >= this.negativeSamplingBoundary, tags);
     }
-    return id >= this.negativeSamplingBoundary;
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -61,17 +61,12 @@ public class ProbabilisticSampler implements Sampler {
    * @return A boolean that says wheter or not to sample.
    */
   @Override
-  public SamplingStatus getSamplingStatus(String operation, long id) {
+  public SamplingStatus sample(String operation, long id) {
     if (id > 0) {
       return SamplingStatus.of(id <= this.positiveSamplingBoundary, tags);
     } else {
       return SamplingStatus.of(id >= this.negativeSamplingBoundary, tags);
     }
-  }
-
-  // Visible for testing
-  Map<String, Object> getTags() {
-    return tags;
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -61,7 +61,7 @@ public class ProbabilisticSampler implements Sampler {
    * @return A boolean that says wheter or not to sample.
    */
   @Override
-  public boolean isSampled(long id) {
+  public boolean isSampled(String operation, long id) {
     if (id > 0) {
       return id <= this.positiveSamplingBoundary;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -69,8 +69,8 @@ public class ProbabilisticSampler implements Sampler {
     }
   }
 
-  @Override
-  public Map<String, Object> getTags() {
+  // Visible for testing
+  Map<String, Object> getTags() {
     return tags;
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -53,8 +53,8 @@ public class RateLimitingSampler implements Sampler {
     return SamplingStatus.of(this.rateLimiter.checkCredit(1.0), tags);
   }
 
-  @Override
-  public Map<String, Object> getTags() {
+  // Visible for testing
+  Map<String, Object> getTags() {
     return tags;
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -49,7 +49,7 @@ public class RateLimitingSampler implements Sampler {
   }
 
   @Override
-  public boolean isSampled(long id) {
+  public boolean isSampled(String operation, long id) {
     return this.rateLimiter.checkCredit(1.0);
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -49,8 +49,8 @@ public class RateLimitingSampler implements Sampler {
   }
 
   @Override
-  public boolean isSampled(String operation, long id) {
-    return this.rateLimiter.checkCredit(1.0);
+  public SamplingStatus getSamplingStatus(String operation, long id) {
+    return SamplingStatus.of(this.rateLimiter.checkCredit(1.0), tags);
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -49,13 +49,8 @@ public class RateLimitingSampler implements Sampler {
   }
 
   @Override
-  public SamplingStatus getSamplingStatus(String operation, long id) {
+  public SamplingStatus sample(String operation, long id) {
     return SamplingStatus.of(this.rateLimiter.checkCredit(1.0), tags);
-  }
-
-  // Visible for testing
-  Map<String, Object> getTags() {
-    return tags;
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -119,9 +119,9 @@ public class RemoteControlledSampler implements Sampler {
   }
 
   @Override
-  public SamplingStatus getSamplingStatus(String operation, long id) {
+  public SamplingStatus sample(String operation, long id) {
     synchronized (this) {
-      return sampler.getSamplingStatus(operation, id);
+      return sampler.sample(operation, id);
     }
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -120,9 +120,9 @@ public class RemoteControlledSampler implements Sampler {
   }
 
   @Override
-  public boolean isSampled(String operation, long id) {
+  public SamplingStatus getSamplingStatus(String operation, long id) {
     synchronized (this) {
-      return sampler.isSampled(operation, id);
+      return sampler.getSamplingStatus(operation, id);
     }
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -120,9 +120,9 @@ public class RemoteControlledSampler implements Sampler {
   }
 
   @Override
-  public boolean isSampled(long id) {
+  public boolean isSampled(String operation, long id) {
     synchronized (this) {
-      return sampler.isSampled(id);
+      return sampler.isSampled(operation, id);
     }
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -29,7 +29,6 @@ import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
 import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
 import com.uber.jaeger.samplers.http.SamplingStrategyType;
 
-import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -123,13 +122,6 @@ public class RemoteControlledSampler implements Sampler {
   public SamplingStatus getSamplingStatus(String operation, long id) {
     synchronized (this) {
       return sampler.getSamplingStatus(operation, id);
-    }
-  }
-
-  @Override
-  public Map<String, Object> getTags() {
-    synchronized (this) {
-      return sampler.getTags();
     }
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
@@ -28,7 +28,7 @@ public interface Sampler {
   /**
    * @return whether or not the new trace should be sampled
    */
-  SamplingStatus getSamplingStatus(String operation, long id);
+  SamplingStatus sample(String operation, long id);
 
   /**
    * Release any resources used by the sampler.

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
@@ -21,8 +21,6 @@
  */
 package com.uber.jaeger.samplers;
 
-import java.util.Map;
-
 /**
  * Sampler is responsible for deciding if a new trace should be sampled and captured for storage.
  */
@@ -31,11 +29,6 @@ public interface Sampler {
    * @return whether or not the new trace should be sampled
    */
   SamplingStatus getSamplingStatus(String operation, long id);
-
-  /**
-   * @return a collection of tags describing this sampler
-   */
-  Map<String, Object> getTags();
 
   /**
    * Release any resources used by the sampler.

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
@@ -28,10 +28,9 @@ import java.util.Map;
  */
 public interface Sampler {
   /**
-   * @param id identified of the new trace
    * @return whether or not the new trace should be sampled
    */
-  boolean isSampled(long id);
+  boolean isSampled(String operation, long id);
 
   /**
    * @return a collection of tags describing this sampler

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingStatus.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingStatus.java
@@ -22,23 +22,10 @@
 package com.uber.jaeger.samplers;
 
 import java.util.Map;
+import lombok.Value;
 
-/**
- * Sampler is responsible for deciding if a new trace should be sampled and captured for storage.
- */
-public interface Sampler {
-  /**
-   * @return whether or not the new trace should be sampled
-   */
-  SamplingStatus getSamplingStatus(String operation, long id);
-
-  /**
-   * @return a collection of tags describing this sampler
-   */
-  Map<String, Object> getTags();
-
-  /**
-   * Release any resources used by the sampler.
-   */
-  void close();
+@Value(staticConstructor = "of")
+public class SamplingStatus {
+  boolean isSampled;
+  Map<String, Object> tags;
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
@@ -35,9 +35,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = 0x3fffffffffffffffL;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.isSampled("", halfwayBoundary));
+    assertTrue(sampler.getSamplingStatus("", halfwayBoundary).isSampled());
 
-    assertFalse(sampler.isSampled("", halfwayBoundary + 2));
+    assertFalse(sampler.getSamplingStatus("", halfwayBoundary + 2).isSampled());
   }
 
   @Test
@@ -46,9 +46,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = -0x4000000000000000L;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.isSampled("", halfwayBoundary));
+    assertTrue(sampler.getSamplingStatus("", halfwayBoundary).isSampled());
 
-    assertFalse(sampler.isSampled("", halfwayBoundary - 1));
+    assertFalse(sampler.getSamplingStatus("", halfwayBoundary - 1).isSampled());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 public class ProbabilisticSamplerTest {
 
   @Test
@@ -35,9 +37,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = 0x3fffffffffffffffL;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.getSamplingStatus("", halfwayBoundary).isSampled());
+    assertTrue(sampler.sample("", halfwayBoundary).isSampled());
 
-    assertFalse(sampler.getSamplingStatus("", halfwayBoundary + 2).isSampled());
+    assertFalse(sampler.sample("", halfwayBoundary + 2).isSampled());
   }
 
   @Test
@@ -46,9 +48,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = -0x4000000000000000L;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.getSamplingStatus("", halfwayBoundary).isSampled());
+    assertTrue(sampler.sample("", halfwayBoundary).isSampled());
 
-    assertFalse(sampler.getSamplingStatus("", halfwayBoundary - 1).isSampled());
+    assertFalse(sampler.sample("", halfwayBoundary - 1).isSampled());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -64,7 +66,8 @@ public class ProbabilisticSamplerTest {
   @Test
   public void testTags() {
     ProbabilisticSampler sampler = new ProbabilisticSampler(0.1);
-    assertEquals("probabilistic", sampler.getTags().get("sampler.type"));
-    assertEquals(0.1, sampler.getTags().get("sampler.param"));
+    Map<String, Object> tags = sampler.sample("vadacurry", 20L).getTags();
+    assertEquals("probabilistic", tags.get("sampler.type"));
+    assertEquals(0.1, tags.get("sampler.param"));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
@@ -21,11 +21,11 @@
  */
 package com.uber.jaeger.samplers;
 
-import org.junit.Test;
-
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 public class ProbabilisticSamplerTest {
 
@@ -35,9 +35,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = 0x3fffffffffffffffL;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.isSampled(halfwayBoundary));
+    assertTrue(sampler.isSampled("", halfwayBoundary));
 
-    assertFalse(sampler.isSampled(halfwayBoundary + 2));
+    assertFalse(sampler.isSampled("", halfwayBoundary + 2));
   }
 
   @Test
@@ -46,9 +46,9 @@ public class ProbabilisticSamplerTest {
 
     long halfwayBoundary = -0x4000000000000000L;
     Sampler sampler = new ProbabilisticSampler(samplingRate);
-    assertTrue(sampler.isSampled(halfwayBoundary));
+    assertTrue(sampler.isSampled("", halfwayBoundary));
 
-    assertFalse(sampler.isSampled(halfwayBoundary - 1));
+    assertFalse(sampler.isSampled("", halfwayBoundary - 1));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
@@ -63,7 +63,7 @@ public class ProbabilisticSamplerTest {
 
   @Test
   public void testTags() {
-    Sampler sampler = new ProbabilisticSampler(0.1);
+    ProbabilisticSampler sampler = new ProbabilisticSampler(0.1);
     assertEquals("probabilistic", sampler.getTags().get("sampler.type"));
     assertEquals(0.1, sampler.getTags().get("sampler.param"));
   }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
@@ -100,7 +100,8 @@ public class RemoteControlledSamplerTest {
   @Test
   public void testTags() throws Exception {
     RemoteControlledSampler sampler = makeSamplerWith(new ProbabilisticSampler(0.5));
-    assertEquals("probabilistic", sampler.getTags().get("sampler.type"));
-    assertEquals(0.5, sampler.getTags().get("sampler.param"));
+    SamplingStatus samplingStatus = sampler.getSamplingStatus("some operation", 1);
+    assertEquals("probabilistic", samplingStatus.getTags().get("sampler.type"));
+    assertEquals(0.5, samplingStatus.getTags().get("sampler.param"));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
@@ -100,7 +100,7 @@ public class RemoteControlledSamplerTest {
   @Test
   public void testTags() throws Exception {
     RemoteControlledSampler sampler = makeSamplerWith(new ProbabilisticSampler(0.5));
-    SamplingStatus samplingStatus = sampler.getSamplingStatus("some operation", 1);
+    SamplingStatus samplingStatus = sampler.sample("some operation", 1);
     assertEquals("probabilistic", samplingStatus.getTags().get("sampler.type"));
     assertEquals(0.5, samplingStatus.getTags().get("sampler.param"));
   }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
@@ -21,13 +21,14 @@
  */
 package com.uber.jaeger.samplers;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class TestConstSampler {
   @Test
   public void testTags() {
-    Sampler sampler = new ConstSampler(true);
+    ConstSampler sampler = new ConstSampler(true);
     assertEquals("const", sampler.getTags().get("sampler.type"));
     assertEquals(true, sampler.getTags().get("sampler.param"));
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
@@ -25,15 +25,15 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 public class TestConstSampler {
   @Test
   public void testTags() {
     ConstSampler sampler = new ConstSampler(true);
-    assertEquals("const", sampler.getTags().get("sampler.type"));
-    assertEquals(true, sampler.getTags().get("sampler.param"));
+    Map<String, Object> tags = sampler.sample("biryani", 218L).getTags();
 
-    sampler = new ConstSampler(false);
-    assertEquals("const", sampler.getTags().get("sampler.type"));
-    assertEquals(false, sampler.getTags().get("sampler.param"));
+    assertEquals("const", tags.get("sampler.type"));
+    assertEquals(true, tags.get("sampler.param"));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
@@ -21,13 +21,14 @@
  */
 package com.uber.jaeger.samplers;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class TestRateLimitingSampler {
   @Test
   public void testTags() {
-    Sampler sampler = new RateLimitingSampler(123);
+    RateLimitingSampler sampler = new RateLimitingSampler(123);
     assertEquals("ratelimiting", sampler.getTags().get("sampler.type"));
     assertEquals(123, sampler.getTags().get("sampler.param"));
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
@@ -25,15 +25,14 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 public class TestRateLimitingSampler {
   @Test
   public void testTags() {
     RateLimitingSampler sampler = new RateLimitingSampler(123);
-    assertEquals("ratelimiting", sampler.getTags().get("sampler.type"));
-    assertEquals(123, sampler.getTags().get("sampler.param"));
-
-    sampler = new RateLimitingSampler(321);
-    assertEquals("ratelimiting", sampler.getTags().get("sampler.type"));
-    assertEquals(321, sampler.getTags().get("sampler.param"));
+    Map<String, Object> tags = sampler.sample("operate", 11).getTags();
+    assertEquals("ratelimiting", tags.get("sampler.type"));
+    assertEquals(123, tags.get("sampler.param"));
   }
 }


### PR DESCRIPTION
In preparation for per operation sampling, 

- `Sampler#isSampled` takes in an operation name
- `Sampler#isSampled` returns a `SamplingStatus` which contains tags
- `Sampler#getTags` is removed