### PR TITLE
Run RemoteReporter's flush timer in daemon thread.

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
@@ -31,7 +31,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,7 +47,6 @@ public class RemoteReporter implements Reporter {
   private final Sender sender;
   private final int maxQueueSize;
   private final Metrics metrics;
-  private static final AtomicLong nextSerialNumber = new AtomicLong(0);
 
   /*
    * RemoteReporter takes a Sender object, and sends spans for a specific protocol, and transport.
@@ -61,14 +59,12 @@ public class RemoteReporter implements Reporter {
     commandQueue = new ArrayBlockingQueue<>(maxQueueSize);
 
     // start a thread to append spans
-    long serialNumber = nextSerialNumber.getAndIncrement();
     queueProcessor = new QueueProcessor();
-    queueProcessorThread =
-        new Thread(queueProcessor, "jaeger.RemoteReporter-QueueProcessor-" + serialNumber);
+    queueProcessorThread = new Thread(queueProcessor, "jaeger.RemoteReporter-QueueProcessor");
     queueProcessorThread.setDaemon(true);
     queueProcessorThread.start();
 
-    flushTimer = new Timer("jaeger.RemoteReporter-FlushTimer-" + serialNumber, true /* isDaemon */);
+    flushTimer = new Timer("jaeger.RemoteReporter-FlushTimer", true /* isDaemon */);
     flushTimer.schedule(
         new TimerTask() {
           @Override

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Uber Technologies, Inc
+ * Copyright (c) 2017, Uber Technologies, Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,8 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RemoteReporterTest {
   private Reporter reporter;
@@ -88,5 +90,18 @@ public class RemoteReporterTest {
         100L, metricsReporter.counters.get("jaeger.reporter-spans.state=success").longValue());
     assertEquals(
         100L, metricsReporter.counters.get("jaeger.traces.sampled=y.state=started").longValue());
+  }
+
+  @Test
+  public void testRemoteReporterFlushTimerThread() throws Exception {
+    int flushTimerThreadCount = 0;
+    for (Thread thread : Thread.getAllStackTraces().keySet()) {
+      if (!thread.getName().startsWith("jaeger.RemoteReporter-FlushTimer")) {
+        continue;
+      }
+      ++flushTimerThreadCount;
+      assertTrue(thread.isDaemon());
+    }
+    assertFalse(flushTimerThreadCount == 0);
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -96,7 +96,7 @@ public class RemoteReporterTest {
   public void testRemoteReporterFlushTimerThread() throws Exception {
     int flushTimerThreadCount = 0;
     for (Thread thread : Thread.getAllStackTraces().keySet()) {
-      if (!thread.getName().startsWith("jaeger.RemoteReporter-FlushTimer")) {
+      if (!thread.getName().equals("jaeger.RemoteReporter-FlushTimer")) {
         continue;
       }
       ++flushTimerThreadCount;


### PR DESCRIPTION
This prevents the flush timer's thread from keeping a process alive after main() has returned.