### PR TITLE
Fix leaky bucket bug

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -40,7 +40,7 @@ public class RateLimitingSampler implements Sampler {
 
   public RateLimitingSampler(double maxTracesPerSecond) {
     this.maxTracesPerSecond = maxTracesPerSecond;
-    this.rateLimiter = new RateLimiter(maxTracesPerSecond);
+    this.rateLimiter = new RateLimiter(maxTracesPerSecond, 1.0);
 
     Map<String, Object> tags = new HashMap<>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -40,7 +40,8 @@ public class RateLimitingSampler implements Sampler {
 
   public RateLimitingSampler(double maxTracesPerSecond) {
     this.maxTracesPerSecond = maxTracesPerSecond;
-    this.rateLimiter = new RateLimiter(maxTracesPerSecond, 1.0);
+    double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
+    this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
 
     Map<String, Object> tags = new HashMap<>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
@@ -34,7 +34,7 @@ public class RateLimiter {
 
   public RateLimiter(double creditsPerSecond, double maxBalance, Clock clock) {
     this.clock = clock;
-    this.balance = creditsPerSecond;
+    this.balance = maxBalance;
     this.maxBalance = maxBalance;
     this.creditsPerNanosecond = creditsPerSecond / 1.0e9;
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
@@ -22,20 +22,20 @@
 package com.uber.jaeger.utils;
 
 public class RateLimiter {
-  private final double creditsPerSecond;
   private final double creditsPerNanosecond;
   private final Clock clock;
   private double balance;
+  private double maxBalance;
   private long lastTick;
 
-  public RateLimiter(double creditsPerSecond) {
-    this(creditsPerSecond, new SystemClock());
+  public RateLimiter(double creditsPerSecond, double maxBalance) {
+    this(creditsPerSecond, maxBalance, new SystemClock());
   }
 
-  public RateLimiter(double creditsPerSecond, Clock clock) {
+  public RateLimiter(double creditsPerSecond, double maxBalance, Clock clock) {
     this.clock = clock;
-    this.creditsPerSecond = creditsPerSecond;
     this.balance = creditsPerSecond;
+    this.maxBalance = maxBalance;
     this.creditsPerNanosecond = creditsPerSecond / 1.0e9;
   }
 
@@ -44,15 +44,13 @@ public class RateLimiter {
     double elapsedTime = currentTime - lastTick;
     lastTick = currentTime;
     balance += elapsedTime * creditsPerNanosecond;
-    double upperbound = Math.max(creditsPerSecond, itemCost);
-    if (balance > upperbound) {
-      balance = upperbound;
+    if (balance > maxBalance) {
+      balance = maxBalance;
     }
     if (balance >= itemCost) {
       balance -= itemCost;
       return true;
     }
-
     return false;
   }
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
@@ -44,10 +44,10 @@ public class RateLimiter {
     double elapsedTime = currentTime - lastTick;
     lastTick = currentTime;
     balance += elapsedTime * creditsPerNanosecond;
-    if (balance > creditsPerSecond) {
-      balance = creditsPerSecond;
+    double upperbound = Math.max(creditsPerSecond, itemCost);
+    if (balance > upperbound) {
+      balance = upperbound;
     }
-
     if (balance >= itemCost) {
       balance -= itemCost;
       return true;

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
@@ -116,4 +116,21 @@ public class RateLimiterTest {
     assertFalse(limiter.checkCredit(0.25));
     assertFalse(limiter.checkCredit(0.25));
   }
+
+  @Test
+  public void testRateLimiterUpperbound() {
+    MockClock clock = new MockClock();
+    RateLimiter limiter = new RateLimiter(0.1, clock);
+
+    long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
+    clock.timeNanos = currentTime;
+    assertFalse(limiter.checkCredit(1.0));
+
+    // move time 20s forward, enough to accumulate credits for 2 messages, but it should still be capped at 1
+    currentTime += TimeUnit.MILLISECONDS.toNanos(2000);
+    clock.timeNanos = currentTime;
+
+    assertTrue(limiter.checkCredit(1.0));
+    assertFalse(limiter.checkCredit(1.0));
+  }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
@@ -54,7 +54,7 @@ public class RateLimiterTest {
   @Test
   public void testRateLimiterWholeNumber() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(2.0, clock);
+    RateLimiter limiter = new RateLimiter(2.0, 2.0, clock);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
@@ -87,7 +87,7 @@ public class RateLimiterTest {
   @Test
   public void testRateLimiterLessThanOne() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(0.5, clock);
+    RateLimiter limiter = new RateLimiter(0.5, 0.5, clock);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
@@ -118,16 +118,16 @@ public class RateLimiterTest {
   }
 
   @Test
-  public void testRateLimiterUpperbound() {
+  public void testRateLimiterMaxBalance() {
     MockClock clock = new MockClock();
-    RateLimiter limiter = new RateLimiter(0.1, clock);
+    RateLimiter limiter = new RateLimiter(0.1, 1.0, clock);
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
     assertFalse(limiter.checkCredit(1.0));
 
     // move time 20s forward, enough to accumulate credits for 2 messages, but it should still be capped at 1
-    currentTime += TimeUnit.MILLISECONDS.toNanos(2000);
+    currentTime += TimeUnit.MILLISECONDS.toNanos(20000);
     clock.timeNanos = currentTime;
 
     assertTrue(limiter.checkCredit(1.0));

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
@@ -124,6 +124,7 @@ public class RateLimiterTest {
 
     long currentTime = TimeUnit.MICROSECONDS.toNanos(100);
     clock.timeNanos = currentTime;
+    assertTrue(limiter.checkCredit(1.0));
     assertFalse(limiter.checkCredit(1.0));
 
     // move time 20s forward, enough to accumulate credits for 2 messages, but it should still be capped at 1


### PR DESCRIPTION
Fix bug where if the creditsPerSecond < itemCost, the leaky bucket never fills up. Added a maxBalance to set the upperbound of the balance.