### PR TITLE
Java 6 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.3.2'
     id "com.github.johnrengelman.shadow" version "1.2.3"
     id "net.ltgt.errorprone" version "0.0.9"
+    id 'ru.vyarus.animalsniffer' version '1.2.0'
 }
 
 
@@ -31,10 +32,6 @@ allprojects {
         mavenCentral()
     }
 
-    repositories {
-        mavenCentral()
-    }
-
     task wrapper(type: Wrapper) {
         gradleVersion = '3.1.2' //version required
     }
@@ -42,11 +39,12 @@ allprojects {
 
 
 subprojects {
+    apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'com.github.hierynomus.license'
     apply plugin: 'java'
     apply plugin: 'maven'
     apply plugin: 'signing'
-    
+
     compileJava {
         sourceCompatibility = 1.6
         targetCompatibility = 1.6
@@ -55,6 +53,10 @@ subprojects {
     compileTestJava {
         sourceCompatibility = 1.7
         targetCompatibility = 1.7
+    }
+
+    animalsniffer {
+        sourceSets = [sourceSets.main]
     }
 
     [compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
@@ -98,6 +100,7 @@ subprojects {
 
     dependencies {
         compileOnly 'org.projectlombok:lombok:1.16.12'
+        compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.15'
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,16 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
     apply plugin: 'signing'
+    
+    compileJava {
+        sourceCompatibility = 1.6
+        targetCompatibility = 1.6
+    }
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    compileTestJava {
+        sourceCompatibility = 1.7
+        targetCompatibility = 1.7
+    }
 
     [compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 

--- a/jaeger-apachehttpclient/build.gradle
+++ b/jaeger-apachehttpclient/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     testCompile group: 'org.mock-server', name: 'mockserver-netty', version: '3.10.4'
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-context/build.gradle
+++ b/jaeger-context/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     // Testing Frameworks
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracedExecutorService.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracedExecutorService.java
@@ -66,7 +66,7 @@ public class TracedExecutorService implements ExecutorService {
 
   @Override
   public <T> Future<T> submit(java.util.concurrent.Callable<T> task) {
-    return delegate.submit(new Callable<>(task, traceContext));
+    return delegate.submit(new Callable<T>(task, traceContext));
   }
 
   @Override
@@ -113,9 +113,9 @@ public class TracedExecutorService implements ExecutorService {
   private <T> Collection<? extends java.util.concurrent.Callable<T>> wrapJaegerCallableCollection(
       Collection<? extends java.util.concurrent.Callable<T>> originalCollection) {
     Collection<java.util.concurrent.Callable<T>> collection =
-        new ArrayList<>(originalCollection.size());
+        new ArrayList<java.util.concurrent.Callable<T>>(originalCollection.size());
     for (java.util.concurrent.Callable<T> c : originalCollection) {
-      collection.add(new Callable<>(c, traceContext));
+      collection.add(new Callable<T>(c, traceContext));
     }
     return collection;
   }

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -22,13 +22,14 @@
 package com.uber.jaeger;
 
 import com.twitter.zipkin.thriftjava.Endpoint;
-import io.opentracing.tag.Tags;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.opentracing.tag.Tags;
 
 public class Span implements io.opentracing.Span {
   private final Tracer tracer;
@@ -59,7 +60,7 @@ public class Span implements io.opentracing.Span {
     this.startTimeMicroseconds = startTimeMicroseconds;
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
-    this.tags = new HashMap<>();
+    this.tags = new HashMap<String, Object>();
 
     for (Map.Entry<String, Object> tag : tags.entrySet()) {
       setTagAsObject(tag.getKey(), tag.getValue());
@@ -205,6 +206,7 @@ public class Span implements io.opentracing.Span {
 
   /**
    * Sets various fields on the {@link Span} when certain {@link Tags} are encountered
+   *
    * @return true iff a special tag is handled
    */
   private boolean handleSpecialTag(String key, Object value) {
@@ -245,23 +247,23 @@ public class Span implements io.opentracing.Span {
    * See {@link #handleSpecialTag(String, Object)}
    */
   private Span setTagAsObject(String key, Object value) {
-      if (key.equals(Tags.SAMPLING_PRIORITY.getKey()) && (value instanceof Number)) {
-        int priority = ((Number) value).intValue();
-        byte newFlags;
-        if (priority > 0) {
-          newFlags = (byte) (context.getFlags() | SpanContext.flagSampled | SpanContext.flagDebug);
-        } else {
-          newFlags = (byte) (context.getFlags() & (~SpanContext.flagSampled));
-        }
-
-        context = context.withFlags(newFlags);
+    if (key.equals(Tags.SAMPLING_PRIORITY.getKey()) && (value instanceof Number)) {
+      int priority = ((Number) value).intValue();
+      byte newFlags;
+      if (priority > 0) {
+        newFlags = (byte) (context.getFlags() | SpanContext.flagSampled | SpanContext.flagDebug);
+      } else {
+        newFlags = (byte) (context.getFlags() & (~SpanContext.flagSampled));
       }
 
-      if (context.isSampled()) {
-        if (!handleSpecialTag(key, value)) {
-          tags.put(key, value);
-        }
+      context = context.withFlags(newFlags);
+    }
+
+    if (context.isSampled()) {
+      if (!handleSpecialTag(key, value)) {
+        tags.put(key, value);
       }
+    }
 
     return this;
   }
@@ -276,7 +278,7 @@ public class Span implements io.opentracing.Span {
     synchronized (this) {
       if (context.isSampled()) {
         if (logs == null) {
-          this.logs = new ArrayList<>();
+          this.logs = new ArrayList<LogData>();
         }
 
         logs.add(new LogData(instantMicroseconds, message, payload));

--- a/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
@@ -132,7 +132,7 @@ public class SpanContext implements io.opentracing.SpanContext {
   }
 
   public SpanContext withBaggageItem(String key, String val) {
-    Map<String, String> newBaggage = new HashMap<>(this.baggage);
+    Map<String, String> newBaggage = new HashMap<String, String>(this.baggage);
     newBaggage.put(key, val);
     return new SpanContext(traceID, spanID, parentID, flags, newBaggage, debugID);
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/InMemoryStatsReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/InMemoryStatsReporter.java
@@ -25,14 +25,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class InMemoryStatsReporter implements StatsReporter {
-  public Map<String, Long> counters = new HashMap<>();
-  public Map<String, Long> gauges = new HashMap<>();
-  public Map<String, Long> timers = new HashMap<>();
+  public Map<String, Long> counters = new HashMap<String, Long>();
+  public Map<String, Long> gauges = new HashMap<String, Long>();
+  public Map<String, Long> timers = new HashMap<String, Long>();
 
   void reset() {
-    counters = new HashMap<>();
-    gauges = new HashMap<>();
-    timers = new HashMap<>();
+    counters = new HashMap<String, Long>();
+    gauges = new HashMap<String, Long>();
+    timers = new HashMap<String, Long>();
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
@@ -40,7 +40,7 @@ public class Metrics {
       }
 
       String metricName = "jaeger.";
-      HashMap<String, String> tags = new HashMap<>();
+      HashMap<String, String> tags = new HashMap<String, String>();
 
       Annotation[] annotations = field.getAnnotations();
       for (Annotation anno : annotations) {
@@ -66,7 +66,7 @@ public class Metrics {
           throw new RuntimeException(
               "A field type that was neither Counter, Gauge, or Timer was parsed in reflection.");
         }
-      } catch (ReflectiveOperationException e) {
+      } catch (Exception e) {
         // This exception should only happen at the start of a program if the code below is not set up correctly.
         // As long as tests are run this code should never be thrown in production.
         throw new RuntimeException(
@@ -84,7 +84,7 @@ public class Metrics {
     StringBuilder sb = new StringBuilder();
     sb.append(name);
 
-    SortedSet<String> sortedKeys = new TreeSet<>(tags.keySet());
+    SortedSet<String> sortedKeys = new TreeSet<String>(tags.keySet());
     for (String key : sortedKeys) {
       sb.append(".");
       sb.append(key);

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
@@ -23,13 +23,14 @@ package com.uber.jaeger.propagation;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.SpanContext;
-import io.opentracing.propagation.TextMap;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.opentracing.propagation.TextMap;
 
 public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   /** Key used to store serialized span context representation */
@@ -78,7 +79,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
         debugID = decodedValue(entry.getValue());
       } else if (key.startsWith(baggagePrefix)) {
         if (baggage == null) {
-          baggage = new HashMap<>();
+          baggage = new HashMap<String, String>();
         }
         baggage.put(keys.unprefixedKey(key, baggagePrefix), decodedValue(entry.getValue()));
       }
@@ -98,9 +99,17 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder();
-    buffer.append("TextMapCodec{").append("contextKey=").append(contextKey).append(',')
-            .append("baggagePrefix=").append(baggagePrefix).append(',')
-            .append("urlEncoding=").append(urlEncoding).append('}');
+    buffer
+        .append("TextMapCodec{")
+        .append("contextKey=")
+        .append(contextKey)
+        .append(',')
+        .append("baggagePrefix=")
+        .append(baggagePrefix)
+        .append(',')
+        .append("urlEncoding=")
+        .append(urlEncoding)
+        .append('}');
     return buffer.toString();
   }
 
@@ -130,6 +139,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
 
   /**
    * Returns a builder for TextMapCodec
+   *
    * @return Builder
    */
   public static Builder builder() {
@@ -160,6 +170,5 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
     public TextMapCodec build() {
       return new TextMapCodec(this);
     }
-
   }
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/CompositeReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/CompositeReporter.java
@@ -32,7 +32,7 @@ public class CompositeReporter implements Reporter {
   private final List<Reporter> reporters;
 
   public CompositeReporter(Reporter... reporters) {
-    this.reporters = new ArrayList<>();
+    this.reporters = new ArrayList<Reporter>();
     for (int i = 0; i < reporters.length; i++) {
       this.reporters.add(reporters[i]);
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
@@ -56,7 +56,7 @@ public class RemoteReporter implements Reporter {
     this.sender = sender;
     this.maxQueueSize = maxQueueSize;
     this.metrics = metrics;
-    commandQueue = new ArrayBlockingQueue<>(maxQueueSize);
+    commandQueue = new ArrayBlockingQueue<Command>(maxQueueSize);
 
     // start a thread to append spans
     queueProcessor = new QueueProcessor();

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverter.java
@@ -46,20 +46,24 @@ public class JaegerThriftSpanConverter {
             span.getOperationName(),
             context.getFlags(),
             span.getStart(),
-            span.getDuration()
-        )
+            span.getDuration())
         .setTags(buildTags(span.getTags()))
         .setLogs(buildLogs(span.getLogs()));
   }
 
   protected static List<Log> buildLogs(List<LogData> logs) {
-    List<Log> jLogs = new ArrayList<>();
+    List<Log> jLogs = new ArrayList<Log>();
     if (logs != null) {
       for (LogData logData : logs) {
         Log jLog = new Log();
         jLog.setTimestamp(logData.getTime());
         final Tag tag = buildTag(logData.getMessage(), logData.getPayload());
-        jLog.setFields(new ArrayList<Tag>() {{add(tag);}});
+        jLog.setFields(
+            new ArrayList<Tag>() {
+              {
+                add(tag);
+              }
+            });
         jLogs.add(jLog);
       }
     }
@@ -67,7 +71,7 @@ public class JaegerThriftSpanConverter {
   }
 
   protected static List<Tag> buildTags(Map<String, Object> tags) {
-    List<Tag> jTags = new ArrayList<>();
+    List<Tag> jTags = new ArrayList<Tag>();
     if (tags != null) {
       for (Map.Entry<String, Object> entry : tags.entrySet()) {
         String tagKey = entry.getKey();

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/TUDPTransport.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/TUDPTransport.java
@@ -24,16 +24,22 @@ package com.uber.jaeger.reporters.protocols;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.net.*;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+
 import lombok.ToString;
 
 /*
  * A thrift transport for sending sending/receiving spans.
  */
 @ToString(exclude = {"writeBuffer"})
-public class TUDPTransport extends TTransport implements AutoCloseable {
+public class TUDPTransport extends TTransport implements Closeable {
   public static final int MAX_PACKET_SIZE = 65000;
 
   public final DatagramSocket socket;

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/ThriftSpanConverter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/ThriftSpanConverter.java
@@ -32,12 +32,14 @@ import com.uber.jaeger.Span;
 import com.uber.jaeger.SpanContext;
 import com.uber.jaeger.Tracer;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class ThriftSpanConverter {
+
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   public static com.twitter.zipkin.thriftjava.Span convertSpan(Span span) {
     Tracer tracer = span.getTracer();
@@ -57,7 +59,7 @@ public class ThriftSpanConverter {
   }
 
   private static List<Annotation> buildAnnotations(Span span, Endpoint host) {
-    List<Annotation> annotations = new ArrayList<>();
+    List<Annotation> annotations = new ArrayList<Annotation>();
 
     if (span.isRPC()) {
       String startLabel = zipkincoreConstants.SERVER_RECV;
@@ -99,10 +101,10 @@ public class ThriftSpanConverter {
     if (!span.isRPC()) {
       byte[] componentName;
       if (span.getLocalComponent() != null) {
-        componentName = span.getLocalComponent().getBytes(StandardCharsets.UTF_8);
+        componentName = span.getLocalComponent().getBytes(UTF_8);
       } else {
         // spans always have associated tracers, and service names
-        componentName = span.getTracer().getServiceName().getBytes(StandardCharsets.UTF_8);
+        componentName = span.getTracer().getServiceName().getBytes(UTF_8);
       }
 
       binaryAnnotations.add(
@@ -133,9 +135,7 @@ public class ThriftSpanConverter {
       tagValue = stringTagValue.substring(0, Constants.MAX_TAG_LENGTH);
     }
 
-    banno
-        .setValue(stringTagValue.getBytes(StandardCharsets.UTF_8))
-        .setAnnotation_type(AnnotationType.STRING);
+    banno.setValue(stringTagValue.getBytes(UTF_8)).setAnnotation_type(AnnotationType.STRING);
 
     return banno;
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -39,7 +39,7 @@ public class ConstSampler implements Sampler {
 
   public ConstSampler(boolean decision) {
     this.decision = decision;
-    Map<String, Object> tags = new HashMap<>();
+    Map<String, Object> tags = new HashMap<String, Object>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);
     tags.put(Constants.SAMPLER_PARAM_TAG_KEY, decision);
     this.tags = Collections.unmodifiableMap(tags);

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/HTTPSamplingManager.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/HTTPSamplingManager.java
@@ -33,7 +33,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
+
 import lombok.ToString;
 
 @ToString
@@ -54,13 +55,16 @@ public class HTTPSamplingManager implements SamplingManager {
     StringBuilder result = new StringBuilder();
     try {
       conn.setRequestMethod("GET");
-      try (BufferedReader rd =
+      BufferedReader rd =
           new BufferedReader(
-              new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+              new InputStreamReader(conn.getInputStream(), Charset.forName("UTF-8")));
+      try {
         String line;
         while ((line = rd.readLine()) != null) {
           result.append(line);
         }
+      } finally {
+        rd.close();
       }
     } finally {
       conn.disconnect();

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -36,8 +36,7 @@ public class ProbabilisticSampler implements Sampler {
 
   private final long positiveSamplingBoundary;
   private final long negativeSamplingBoundary;
-  @Getter
-  private final double samplingRate;
+  @Getter private final double samplingRate;
   private final Map<String, Object> tags;
 
   public ProbabilisticSampler(double samplingRate) {
@@ -50,7 +49,7 @@ public class ProbabilisticSampler implements Sampler {
     this.positiveSamplingBoundary = (long) (((1L << 63) - 1) * samplingRate);
     this.negativeSamplingBoundary = (long) ((1L << 63) * samplingRate);
 
-    Map<String, Object> tags = new HashMap<>();
+    Map<String, Object> tags = new HashMap<String, Object>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);
     tags.put(Constants.SAMPLER_PARAM_TAG_KEY, samplingRate);
     this.tags = Collections.unmodifiableMap(tags);

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -43,7 +43,7 @@ public class RateLimitingSampler implements Sampler {
     double maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
     this.rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
 
-    Map<String, Object> tags = new HashMap<>();
+    Map<String, Object> tags = new HashMap<String, Object>();
     tags.put(Constants.SAMPLER_TYPE_TAG_KEY, TYPE);
     tags.put(Constants.SAMPLER_PARAM_TAG_KEY, maxTracesPerSecond);
     this.tags = Collections.unmodifiableMap(tags);

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/InMemorySender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/InMemorySender.java
@@ -35,21 +35,21 @@ public class InMemorySender implements Sender {
   private List<Span> received;
 
   public InMemorySender() {
-    appended = new ArrayList<>();
-    flushed = new ArrayList<>();
-    received = new ArrayList<>();
+    appended = new ArrayList<Span>();
+    flushed = new ArrayList<Span>();
+    received = new ArrayList<Span>();
   }
 
   public List<Span> getAppended() {
-    return new ArrayList<>(appended);
+    return new ArrayList<Span>(appended);
   }
 
   public List<Span> getFlushed() {
-    return new ArrayList<>(flushed);
+    return new ArrayList<Span>(flushed);
   }
 
   public List<Span> getReceived() {
-    return new ArrayList<>(received);
+    return new ArrayList<Span>(received);
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/UDPSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/UDPSender.java
@@ -65,7 +65,7 @@ public class UDPSender implements Sender {
     udpTransport = TUDPTransport.NewTUDPClient(host, port);
     udpClient = new Agent.Client(new TCompactProtocol(udpTransport));
     maxSpanBytes = maxPacketSize - emitZipkinBatchOverhead;
-    spanBuffer = new ArrayList<>();
+    spanBuffer = new ArrayList<Span>();
   }
 
   int getSizeOfSerializedSpan(Span span) throws SenderException {

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, Uber Technologies, Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.jaeger.utils;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class Java6CompatibleThreadLocalRandom {
+
+  private static final boolean THREAD_LOCAL_RANDOM_PRESENT;
+
+  private static final String THREAD_LOCAL_RANDOM_CLASS_NAME =
+      "java.util.concurrent.ThreadLocalRandom";
+
+  static {
+    boolean present = true;
+    try {
+      Class.forName(THREAD_LOCAL_RANDOM_CLASS_NAME);
+    } catch (ClassNotFoundException e) {
+      present = false;
+    }
+    THREAD_LOCAL_RANDOM_PRESENT = present;
+  }
+
+  private static final ThreadLocal<Random> threadLocal =
+      new ThreadLocal<Random>() {
+        @Override
+        protected Random initialValue() {
+          return new Random();
+        }
+      };
+
+  /**
+   * Calls {@link ThreadLocalRandom#current()}, if this class is present (if you are using Java 7).
+   * Otherwise uses a Java 6 compatible fallback.
+   *
+   * @return the current thread's {@link Random}
+   */
+  public static Random current() {
+    if (THREAD_LOCAL_RANDOM_PRESENT) {
+      return ThreadLocalRandom.current();
+    } else {
+      return threadLocal.get();
+    }
+  }
+
+  private Java6CompatibleThreadLocalRandom() {}
+}

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
@@ -28,19 +28,17 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class Java6CompatibleThreadLocalRandom {
 
-  static final boolean THREAD_LOCAL_RANDOM_PRESENT;
+  static boolean threadLocalRandomPresent = true;
 
   private static final String THREAD_LOCAL_RANDOM_CLASS_NAME =
       "java.util.concurrent.ThreadLocalRandom";
 
   static {
-    boolean present = true;
     try {
       Class.forName(THREAD_LOCAL_RANDOM_CLASS_NAME);
     } catch (ClassNotFoundException e) {
-      present = false;
+      threadLocalRandomPresent = false;
     }
-    THREAD_LOCAL_RANDOM_PRESENT = present;
   }
 
   private static final ThreadLocal<Random> threadLocal =
@@ -59,7 +57,7 @@ public final class Java6CompatibleThreadLocalRandom {
    */
   @IgnoreJRERequirement
   public static Random current() {
-    if (THREAD_LOCAL_RANDOM_PRESENT) {
+    if (threadLocalRandomPresent) {
       return ThreadLocalRandom.current();
     } else {
       return threadLocal.get();

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Utils.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Utils.java
@@ -26,7 +26,6 @@ import com.uber.jaeger.exceptions.NotFourOctetsException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class Utils {
   public static String normalizeBaggageKey(String key) {
@@ -59,8 +58,12 @@ public class Utils {
   public static long uniqueID() {
     long val = 0;
     while (val == 0) {
-      val = ThreadLocalRandom.current().nextLong();
+      val = Java6CompatibleThreadLocalRandom.current().nextLong();
     }
     return val;
+  }
+
+  public static boolean equals(Object a, Object b) {
+    return (a == b) || (a != null && a.equals(b));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
@@ -21,26 +21,57 @@
  */
 package com.uber.jaeger.utils;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 public class Java6CompatibleThreadLocalRandomTest {
 
+    @After
+    @Before
+    public void clearState() throws Exception {
+        // As test classes are targeted at 1.7 and gradle 3.x can't be run with Java 6,
+        // its safe to say that this test won't ever be executed with JDK 6
+        Java6CompatibleThreadLocalRandom.threadLocalRandomPresent = true;
+    }
+
     @Test
-    public void testGetCurrentRandom() throws Exception {
-        if (System.getProperty("java.version").startsWith("1.6.")) {
-            assertFalse(Java6CompatibleThreadLocalRandom.THREAD_LOCAL_RANDOM_PRESENT);
-        } else {
-            assertTrue(Java6CompatibleThreadLocalRandom.THREAD_LOCAL_RANDOM_PRESENT);
-            assertSame(Java6CompatibleThreadLocalRandom.current(), ThreadLocalRandom.current());
-        }
+    public void testThreadLocalRandomPresent() throws Exception {
+        assertSame(Java6CompatibleThreadLocalRandom.current(), ThreadLocalRandom.current());
         assertNotNull(Java6CompatibleThreadLocalRandom.current().nextLong());
+    }
+
+    @Test
+    public void testThreadLocalRandomNotPresent() throws Exception {
+        Java6CompatibleThreadLocalRandom.threadLocalRandomPresent = false;
+        assertNotSame(Java6CompatibleThreadLocalRandom.current(), ThreadLocalRandom.current());
+        assertNotNull(Java6CompatibleThreadLocalRandom.current().nextLong());
+    }
+
+    @Test
+    public void testRandomFromOtherThreadIsNotSame() throws Exception {
+        Java6CompatibleThreadLocalRandom.threadLocalRandomPresent = false;
+        final AtomicReference<Random> randomFromOtherThread = new AtomicReference<>();
+        final Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                randomFromOtherThread.set(Java6CompatibleThreadLocalRandom.current());
+            }
+        });
+        thread.start();
+        thread.join();
+        assertNotSame(Java6CompatibleThreadLocalRandom.current(), randomFromOtherThread.get());
+        assertNotNull(Java6CompatibleThreadLocalRandom.current().nextLong());
+        assertNotNull(randomFromOtherThread.get());
+        assertNotNull(randomFromOtherThread.get().nextLong());
     }
 
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
@@ -21,50 +21,26 @@
  */
 package com.uber.jaeger.utils;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import org.junit.Test;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
-public final class Java6CompatibleThreadLocalRandom {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
-  static final boolean THREAD_LOCAL_RANDOM_PRESENT;
+public class Java6CompatibleThreadLocalRandomTest {
 
-  private static final String THREAD_LOCAL_RANDOM_CLASS_NAME =
-      "java.util.concurrent.ThreadLocalRandom";
-
-  static {
-    boolean present = true;
-    try {
-      Class.forName(THREAD_LOCAL_RANDOM_CLASS_NAME);
-    } catch (ClassNotFoundException e) {
-      present = false;
-    }
-    THREAD_LOCAL_RANDOM_PRESENT = present;
-  }
-
-  private static final ThreadLocal<Random> threadLocal =
-      new ThreadLocal<Random>() {
-        @Override
-        protected Random initialValue() {
-          return new Random();
+    @Test
+    public void testGetCurrentRandom() throws Exception {
+        if (System.getProperty("java.version").startsWith("1.6.")) {
+            assertFalse(Java6CompatibleThreadLocalRandom.THREAD_LOCAL_RANDOM_PRESENT);
+        } else {
+            assertTrue(Java6CompatibleThreadLocalRandom.THREAD_LOCAL_RANDOM_PRESENT);
+            assertSame(Java6CompatibleThreadLocalRandom.current(), ThreadLocalRandom.current());
         }
-      };
-
-  /**
-   * Calls {@link ThreadLocalRandom#current()}, if this class is present (if you are using Java 7).
-   * Otherwise uses a Java 6 compatible fallback.
-   *
-   * @return the current thread's {@link Random}
-   */
-  @IgnoreJRERequirement
-  public static Random current() {
-    if (THREAD_LOCAL_RANDOM_PRESENT) {
-      return ThreadLocalRandom.current();
-    } else {
-      return threadLocal.get();
+        assertNotNull(Java6CompatibleThreadLocalRandom.current().nextLong());
     }
-  }
 
-  private Java6CompatibleThreadLocalRandom() {}
 }

--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -5,6 +5,11 @@ description = 'A jaeger instrumented java server meant for testing interoperabil
 ext.jacksonVersion = '2.7.4'
 shadowJar.archiveName = 'jaeger-crossdock.jar'
 
+compileJava {
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+}
+
 dependencies {
     compile project(':jaeger-jaxrs2')
 

--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 
     // Testing Frameworks
     testCompile group: 'junit', name: 'junit', version: junitVersion
+
+    signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 
 sourceSets {

--- a/jaeger-dropwizard/build.gradle
+++ b/jaeger-dropwizard/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
@@ -43,7 +43,8 @@ public class JaegerFeature implements Feature {
 
     switch (featureContext.getConfiguration().getRuntimeType()) {
       case SERVER:
-        featureContext.register(new JerseyServerFilter(tracer, com.uber.jaeger.context.TracingUtils.getTraceContext()));
+        featureContext.register(
+            new JerseyServerFilter(tracer, com.uber.jaeger.context.TracingUtils.getTraceContext()));
         break;
       case CLIENT:
         featureContext.register(TracingUtils.clientFilter(tracer));

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -25,7 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ServerFilter;
-import io.opentracing.Tracer;
+
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ExtendedUriInfo;
 import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
@@ -36,17 +36,20 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.ext.Provider;
+
+import io.opentracing.Tracer;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * A {@link ServerFilter} that provides a Jersey specific {@link #getOperationName} implementation.
- * When using this Filter with Jersey, the full @Path template hierarchy is used as the
- * operation name.
+ * When using this Filter with Jersey, the full @Path template hierarchy is used as the operation
+ * name.
  *
  * WARNING: This class relies on an private implementation detail
  * {@link UriTemplate#normalizedTemplate} to provide functionality.
@@ -56,11 +59,10 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class JerseyServerFilter extends ServerFilter {
 
-  private Map<CacheKey, String> methodToPathCache = new ConcurrentHashMap<>();
+  private Map<CacheKey, String> methodToPathCache = new ConcurrentHashMap<CacheKey, String>();
   private Field normalizedTemplate;
 
-  public JerseyServerFilter(Tracer tracer,
-                            TraceContext traceContext) {
+  public JerseyServerFilter(Tracer tracer, TraceContext traceContext) {
     super(tracer, traceContext);
 
     try {
@@ -68,19 +70,23 @@ public class JerseyServerFilter extends ServerFilter {
       normalizedTemplate.setAccessible(true);
     } catch (NoSuchFieldException e) {
       //TODO: Add metrics for failure counts
-      log.error("Cannot access the normalizedTemplate field from UriTemplate. "
-                    + "Path operation name for tracing will be disabled.", e);
+      log.error(
+          "Cannot access the normalizedTemplate field from UriTemplate. "
+              + "Path operation name for tracing will be disabled.",
+          e);
     }
   }
 
   /**
    * Gets an operation name by first calling {@link #getPathOperationName(ContainerRequestContext)},
    * and falling back on {@link #getResourceMethodOperationName(ContainerRequestContext)}.
+   *
    * @return operation name
    */
   @Override
   protected String getOperationName(ContainerRequestContext containerRequestContext) {
-    CacheKey key  = CacheKey.of(resourceInfo.getResourceMethod(), containerRequestContext.getMethod());
+    CacheKey key =
+        CacheKey.of(resourceInfo.getResourceMethod(), containerRequestContext.getMethod());
     String operationName = methodToPathCache.get(key);
     if (operationName != null) {
       return operationName;
@@ -98,17 +104,22 @@ public class JerseyServerFilter extends ServerFilter {
 
   /**
    * Retrieves an operation name that uses the resource method name of the matched jersey resource
+   *
    * @return the operation name
    */
   private String getResourceMethodOperationName(ContainerRequestContext containerRequestContext) {
     Method method = resourceInfo.getResourceMethod();
-    return String.format("%s:%s:%s", containerRequestContext.getMethod(),
-                         method.getDeclaringClass().getCanonicalName(), method.getName());
+    return String.format(
+        "%s:%s:%s",
+        containerRequestContext.getMethod(),
+        method.getDeclaringClass().getCanonicalName(),
+        method.getName());
   }
 
   /**
-   * Retrieves an operation name that contains the http method and value of the
-   * {@link Path} used by a Jersey server implementation.
+   * Retrieves an operation name that contains the http method and value of the {@link Path} used by
+   * a Jersey server implementation.
+   *
    * @return the operation name
    */
   private String getPathOperationName(ContainerRequestContext containerRequestContext) {
@@ -136,11 +147,11 @@ public class JerseyServerFilter extends ServerFilter {
   }
 
   @VisibleForTesting
-  Map<CacheKey, String> getCache(){
-    return new ConcurrentHashMap<>(methodToPathCache);
+  Map<CacheKey, String> getCache() {
+    return new ConcurrentHashMap<CacheKey, String>(methodToPathCache);
   }
 
-  @Value (staticConstructor = "of")
+  @Value(staticConstructor = "of")
   static class CacheKey {
     private final Method resourceMethod;
     private final String httpMethod;

--- a/jaeger-jaxrs2/build.gradle
+++ b/jaeger-jaxrs2/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     testCompile group: 'org.glassfish.jersey.media', name: 'jersey-media-moxy', version: jerseyVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -7,6 +7,8 @@ description = 'Generated thrift code'
 
 dependencies {
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 /**

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -9,6 +9,12 @@ dependencies {
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 }
 
+/**
+ * Note that you need to install thrift 0.9.2 on your system for this task to work.
+ *
+ * If you are using macOS, you can install this specific version via homebrew like so:
+ * `brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/56d8c1eba1e5ac30290dd0c486f4bba37f821e42/Formula/thrift.rb`
+ */
 compileThrift {
     sourceDir "${projectDir}/../idl/thrift"
     outputDir 'src/main/gen-java'

--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile group: 'io.zipkin.java', name: 'zipkin-junit', version: '1.16.2'
     testCompile group: 'io.zipkin.brave', name: 'brave-http', version: '3.15.3'
+
+    signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
 sourceSets {

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
@@ -101,20 +101,18 @@ public final class ZipkinSender implements Sender {
     byte[] next = encoder.encode(backFillHostOnAnnotations(span));
     int messageSizeOfNextSpan = delegate.messageSizeInBytes(Collections.singletonList(next));
     // don't enqueue something larger than we can drain
-    if (Integer.valueOf(messageSizeOfNextSpan).compareTo(delegate.messageMaxBytes()) > 0) {
+    if (messageSizeOfNextSpan > delegate.messageMaxBytes()) {
       throw new SenderException(
           delegate.toString() + " received a span that was too large", null, 1);
     }
 
     spanBuffer.add(next); // speculatively add to the buffer so we can size it
     int nextSizeInBytes = delegate.messageSizeInBytes(spanBuffer);
-    int includingNextVsMaxMessageSize =
-        Integer.valueOf(nextSizeInBytes).compareTo(delegate.messageMaxBytes());
     // If we can fit queued spans and the next into one message...
-    if (includingNextVsMaxMessageSize <= 0) {
+    if (nextSizeInBytes <= delegate.messageMaxBytes()) {
 
       // If there's still room, don't flush yet.
-      if (includingNextVsMaxMessageSize < 0) {
+      if (nextSizeInBytes < delegate.messageMaxBytes()) {
         return 0;
       }
       // If we have exactly met the max message size, flush

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
@@ -101,7 +101,7 @@ public final class ZipkinSender implements Sender {
     byte[] next = encoder.encode(backFillHostOnAnnotations(span));
     int messageSizeOfNextSpan = delegate.messageSizeInBytes(Collections.singletonList(next));
     // don't enqueue something larger than we can drain
-    if (Integer.compare(messageSizeOfNextSpan, delegate.messageMaxBytes()) > 0) {
+    if (Integer.valueOf(messageSizeOfNextSpan).compareTo(delegate.messageMaxBytes()) > 0) {
       throw new SenderException(
           delegate.toString() + " received a span that was too large", null, 1);
     }
@@ -109,7 +109,7 @@ public final class ZipkinSender implements Sender {
     spanBuffer.add(next); // speculatively add to the buffer so we can size it
     int nextSizeInBytes = delegate.messageSizeInBytes(spanBuffer);
     int includingNextVsMaxMessageSize =
-        Integer.compare(nextSizeInBytes, delegate.messageMaxBytes());
+        Integer.valueOf(nextSizeInBytes).compareTo(delegate.messageMaxBytes());
     // If we can fit queued spans and the next into one message...
     if (includingNextVsMaxMessageSize <= 0) {
 


### PR DESCRIPTION
Checked with IntelliJ:
Run Inspection by Name >
Usages of API which isn't available at the configured language level

jaeger-crossdock still requires Java 7 because it calls
InetAddress#getLoopbackAddress()

(closes #129)