### PR TITLE
Enable process level tags to be associated with the tracer

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -71,7 +71,8 @@ public class Tracer implements io.opentracing.Tracer {
       Sampler sampler,
       PropagationRegistry registry,
       Clock clock,
-      Metrics metrics) {
+      Metrics metrics,
+      Map<String, Object> tags) {
     this.serviceName = serviceName;
     this.reporter = reporter;
     this.sampler = sampler;
@@ -89,7 +90,6 @@ public class Tracer implements io.opentracing.Tracer {
 
     this.version = loadVersion();
 
-    Map<String, Object> tags = new HashMap<String, Object>();
     tags.put("jaeger.version", this.version);
     String hostname = getHostName();
     if (hostname != null) {
@@ -326,6 +326,7 @@ public class Tracer implements io.opentracing.Tracer {
     private Metrics metrics;
     private String serviceName;
     private Clock clock = new SystemClock();
+    private Map<String, Object> tags = new HashMap<String, Object>();
 
     public Builder(String serviceName, Reporter reporter, Sampler sampler) {
       if (serviceName == null || serviceName.trim().length() == 0) {
@@ -370,8 +371,23 @@ public class Tracer implements io.opentracing.Tracer {
       return this;
     }
 
+    Builder withTag(String key, String value) {
+      tags.put(key, value);
+      return this;
+    }
+
+    Builder withTag(String key, boolean value) {
+      tags.put(key, value);
+      return this;
+    }
+
+    Builder withTag(String key, Number value) {
+      tags.put(key, value);
+      return this;
+    }
+
     public Tracer build() {
-      return new Tracer(this.serviceName, reporter, sampler, registry, clock, metrics);
+      return new Tracer(this.serviceName, reporter, sampler, registry, clock, metrics, tags);
     }
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
@@ -66,18 +66,21 @@ public class TracerTagsTest {
     Map<String, Object> rootTags = new HashMap<>();
     rootTags.put("jaeger.version", tracer.getVersion());
     rootTags.put("jaeger.hostname", hostname);
+    rootTags.put("tracer.tag", "y");
     rootTags.put("sampler.type", "const");
     rootTags.put("sampler.param", true);
 
     Map<String, Object> childTags = new HashMap<>();
     childTags.put("jaeger.version", SENTINEL);
     childTags.put("jaeger.hostname", SENTINEL);
+    childTags.put("tracer.tag", SENTINEL);
     childTags.put("sampler.type", SENTINEL);
     childTags.put("sampler.param", SENTINEL);
 
     Map<String, Object> rpcTags = new HashMap<>();
     rpcTags.put("jaeger.version", tracer.getVersion());
     rpcTags.put("jaeger.hostname", hostname);
+    rpcTags.put("tracer.tag", "y");
     rpcTags.put("sampler.type", SENTINEL);
     rpcTags.put("sampler.param", SENTINEL);
 
@@ -94,7 +97,9 @@ public class TracerTagsTest {
   @Test
   public void testTracerTags() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
-    Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true))
+            .withTag("tracer.tag", "y")
+            .build();
 
     Span span = (Span) tracer.buildSpan("root").start();
     if (spanType == SpanType.CHILD) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
@@ -66,21 +66,27 @@ public class TracerTagsTest {
     Map<String, Object> rootTags = new HashMap<>();
     rootTags.put("jaeger.version", tracer.getVersion());
     rootTags.put("jaeger.hostname", hostname);
-    rootTags.put("tracer.tag", "y");
+    rootTags.put("tracer.tag.str", "y");
+    rootTags.put("tracer.tag.bool", true);
+    rootTags.put("tracer.tag.num", 1);
     rootTags.put("sampler.type", "const");
     rootTags.put("sampler.param", true);
 
     Map<String, Object> childTags = new HashMap<>();
     childTags.put("jaeger.version", SENTINEL);
     childTags.put("jaeger.hostname", SENTINEL);
-    childTags.put("tracer.tag", SENTINEL);
+    childTags.put("tracer.tag.str", SENTINEL);
+    childTags.put("tracer.tag.bool", SENTINEL);
+    childTags.put("tracer.tag.num", SENTINEL);
     childTags.put("sampler.type", SENTINEL);
     childTags.put("sampler.param", SENTINEL);
 
     Map<String, Object> rpcTags = new HashMap<>();
     rpcTags.put("jaeger.version", tracer.getVersion());
     rpcTags.put("jaeger.hostname", hostname);
-    rpcTags.put("tracer.tag", "y");
+    rpcTags.put("tracer.tag.str", "y");
+    rpcTags.put("tracer.tag.bool", true);
+    rpcTags.put("tracer.tag.num", 1);
     rpcTags.put("sampler.type", SENTINEL);
     rpcTags.put("sampler.param", SENTINEL);
 
@@ -98,7 +104,9 @@ public class TracerTagsTest {
   public void testTracerTags() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
     Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true))
-            .withTag("tracer.tag", "y")
+            .withTag("tracer.tag.str", "y")
+            .withTag("tracer.tag.bool", true)
+            .withTag("tracer.tag.num", 1)
             .build();
 
     Span span = (Span) tracer.buildSpan("root").start();


### PR DESCRIPTION
Inline with the new jaeger model, where tags can be associated with the process, this change enables some process level tags to be specified when building the `Tracer`.