### PR TITLE
Google checkstyle with gradle checkstyle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,28 +133,16 @@ This allows using Jaeger UI to find the trace by this tag.
 ## Developing
 
  1. `git submodule init update`
- 2. `./gradlew googleJavaFormat clean test`
+ 2. `./gradlew clean check`
  
 ### Code Style
 
-This project uses [google java style](https://google.github.io/styleguide/javaguide.html).
-It is recommended to set up a git precommit hook as follows.
-```
-cat>.git/hooks/pre-commit
-#!/bin/sh
-#
-# Pre-commit hooks
-# Format code using the google formatter
-echo "pre-commit code format"
-./gradlew googleJavaFormat
-^D
-```
-```
-chmod a+x .git/hooks/pre-commit
-```
+This project uses [google java style](https://google.github.io/styleguide/javaguide.html) configured 
+via [checkstyle/google_checks.xml](https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml)
 
 You can also setup the [IntelliJ plugin](https://plugins.jetbrains.com/plugin/8527)
-to reformat code from within your IDE
+to reformat code from within your IDE or import code style settings from 
+[google/intellij-java-google-style](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
 
 ### Lombok
 This project uses [Lombok](https://projectlombok.org/) to reduce boilerplate. You can setup

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
     apply plugin: 'signing'
+    apply plugin: 'checkstyle'
 
     compileJava {
         sourceCompatibility = 1.6
@@ -64,10 +65,14 @@ subprojects {
             configurations.compile.each { File file -> println file.name }
         }
     }
-    
-    task verifyFormatting(type: com.github.sherter.googlejavaformatgradleplugin.VerifyGoogleJavaFormat) {
-        exclude '**/gen-java/**'
+
+    checkstyle {
+        configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+        toolVersion = "7.6.1"
     }
+
+    // TODO fix tests
+    checkstyleTest.enabled = false
 
     license {
         header rootProject.file('license-template')
@@ -83,7 +88,6 @@ subprojects {
     }
 
     check.dependsOn tasks.license
-    classes.dependsOn tasks.verifyFormatting
 
     apply from: '../gradle/publish.gradle'
     test {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,8 +1,222 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
-<module name="Checker">
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
     <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="120"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="100"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <!-- TODO enable -->
+        <!--<module name="JavadocTagContinuationIndentation"/>-->
+        <!-- TODO enable -->
+        <!--<module name="SummaryJavadoc">-->
+            <!--<property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>-->
+        <!--</module>-->
+        <!-- TODO enable -->
+        <!--<module name="JavadocParagraph"/>-->
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <!-- TODO enable -->
+        <!--<module name="JavadocMethod">-->
+            <!--<property name="scope" value="public"/>-->
+            <!--<property name="allowMissingParamTags" value="true"/>-->
+            <!--<property name="allowMissingThrowsTags" value="true"/>-->
+            <!--<property name="allowMissingReturnTag" value="true"/>-->
+            <!--<property name="minLineCount" value="2"/>-->
+            <!--<property name="allowedAnnotations" value="Override, Test"/>-->
+            <!--<property name="allowThrowsTagsForSubclasses" value="true"/>-->
+        <!--</module>-->
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
 </module>

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/ClientRequestCarrier.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/ClientRequestCarrier.java
@@ -19,14 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.httpclient;
 
 import io.opentracing.propagation.TextMap;
-import org.apache.http.HttpRequest;
-import org.apache.http.message.BasicHeader;
-
 import java.util.Iterator;
 import java.util.Map;
+import org.apache.http.HttpRequest;
+import org.apache.http.message.BasicHeader;
 
 /**
  * This is used propagate spans from the apache http client to servers that it is interacting with.

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/Constants.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/Constants.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.httpclient;
 
 public class Constants {

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingInterceptors.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingInterceptors.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.httpclient;
 
 import io.opentracing.Tracer;

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.httpclient;
 
 import com.uber.jaeger.context.TraceContext;
@@ -27,6 +28,8 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -34,9 +37,6 @@ import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.RequestLine;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.protocol.HttpContext;
-
-import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Apache http client request interceptor This is designed to be used along with

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingResponseInterceptor.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingResponseInterceptor.java
@@ -19,17 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.httpclient;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.protocol.HttpContext;
-
-import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Apache http client response interceptor that works in conjunction with

--- a/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
+++ b/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
@@ -30,6 +30,7 @@ import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.samplers.Sampler;
+import java.util.List;
 import org.apache.http.HttpHost;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -48,8 +49,6 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
-
-import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JaegerRequestAndResponseInterceptorIntegrationTest {
@@ -128,15 +127,15 @@ public class JaegerRequestAndResponseInterceptorIntegrationTest {
     assertEquals(2, spans.size());
     Span span = spans.get(1);
     assertEquals("GET", span.getOperationName());
-    assertEquals(parentSpan.context().getSpanID(), span.context().getParentID());
+    assertEquals(parentSpan.context().getSpanId(), span.context().getParentId());
 
     //Assert traces and baggage are propagated correctly to server
     HttpRequest[] httpRequests = mockServerClient.retrieveRecordedRequests(null);
     assertEquals(1, httpRequests.length);
     String traceData = httpRequests[0].getFirstHeader("uber-trace-id");
     String[] split = traceData.split("%3A");
-    assertEquals(Long.toHexString(span.context().getTraceID()), split[0]);
-    assertEquals(Long.toHexString(span.context().getSpanID()), split[1]);
+    assertEquals(Long.toHexString(span.context().getTraceId()), split[0]);
+    assertEquals(Long.toHexString(span.context().getSpanId()), split[1]);
     String baggage = httpRequests[0].getFirstHeader("uberctx-" + BAGGAGE_KEY);
     assertEquals(BAGGAGE_VALUE, baggage);
   }

--- a/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
+++ b/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
@@ -19,13 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation.b3;
 
 import com.uber.jaeger.SpanContext;
 import com.uber.jaeger.propagation.Extractor;
 import com.uber.jaeger.propagation.Injector;
 import io.opentracing.propagation.TextMap;
-
 import java.util.Map;
 
 /**
@@ -57,11 +57,11 @@ public final class B3TextMapCodec implements Injector<TextMap>, Extractor<TextMa
 
   @Override
   public void inject(SpanContext spanContext, TextMap carrier) {
-    carrier.put(TRACE_ID_NAME, HexCodec.toLowerHex(spanContext.getTraceID()));
-    if (spanContext.getParentID() != 0L) { // Conventionally, parent id == 0 means the root span
-      carrier.put(PARENT_SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getParentID()));
+    carrier.put(TRACE_ID_NAME, HexCodec.toLowerHex(spanContext.getTraceId()));
+    if (spanContext.getParentId() != 0L) { // Conventionally, parent id == 0 means the root span
+      carrier.put(PARENT_SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getParentId()));
     }
-    carrier.put(SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getSpanID()));
+    carrier.put(SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getSpanId()));
     carrier.put(SAMPLED_NAME, spanContext.isSampled() ? "1" : "0");
     if (spanContext.isDebug()) {
       carrier.put(FLAGS_NAME, "1");
@@ -70,9 +70,9 @@ public final class B3TextMapCodec implements Injector<TextMap>, Extractor<TextMa
 
   @Override
   public SpanContext extract(TextMap carrier) {
-    Long traceID = null;
-    Long spanID = null;
-    long parentID = 0L; // Conventionally, parent id == 0 means the root span
+    Long traceId = null;
+    Long spanId = null;
+    long parentId = 0L; // Conventionally, parent id == 0 means the root span
     byte flags = 0;
     for (Map.Entry<String, String> entry : carrier) {
       if (entry.getKey().equalsIgnoreCase(SAMPLED_NAME)) {
@@ -80,11 +80,11 @@ public final class B3TextMapCodec implements Injector<TextMap>, Extractor<TextMa
           flags |= SAMPLED_FLAG;
         }
       } else if (entry.getKey().equalsIgnoreCase(TRACE_ID_NAME)) {
-        traceID = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+        traceId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
       } else if (entry.getKey().equalsIgnoreCase(PARENT_SPAN_ID_NAME)) {
-        parentID = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+        parentId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
       } else if (entry.getKey().equalsIgnoreCase(SPAN_ID_NAME)) {
-        spanID = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+        spanId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
       } else if (entry.getKey().equalsIgnoreCase(FLAGS_NAME)) {
         if (entry.getValue().equals("1")) {
           flags |= DEBUG_FLAG;
@@ -92,8 +92,8 @@ public final class B3TextMapCodec implements Injector<TextMap>, Extractor<TextMa
       }
     }
 
-    if (traceID != null && spanID != null) {
-      return new SpanContext(traceID, spanID, parentID, flags);
+    if (traceId != null && spanId != null) {
+      return new SpanContext(traceId, spanId, parentId, flags);
     }
     return null;
   }

--- a/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/HexCodec.java
+++ b/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/HexCodec.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation.b3;
 
 // copy/pasted from brave.internal.HexCodec 4.1.1 to avoid build complexity
@@ -30,7 +31,9 @@ final class HexCodec {
    */
   static long lowerHexToUnsignedLong(String lowerHex) {
     int length = lowerHex.length();
-    if (length < 1 || length > 32) throw isntLowerHexLong(lowerHex);
+    if (length < 1 || length > 32) {
+      throw isntLowerHexLong(lowerHex);
+    }
 
     // trim off any high bits
     int beginIndex = length > 16 ? length - 16 : 0;
@@ -63,7 +66,9 @@ final class HexCodec {
         lowerHex + " should be a 1 to 32 character lower-hex string with no prefix");
   }
 
-  /** Returns 16 or 32 character hex string depending on if {@code high} is zero. */
+  /**
+   * Returns 16 or 32 character hex string depending on if {@code high} is zero.
+   */
   static String toLowerHex(long high, long low) {
     char[] result = new char[high != 0 ? 32 : 16];
     int pos = 0;
@@ -75,14 +80,18 @@ final class HexCodec {
     return new String(result);
   }
 
-  /** Inspired by {@code okio.Buffer.writeLong} */
+  /**
+   * Inspired by {@code okio.Buffer.writeLong}
+   */
   static String toLowerHex(long v) {
     char[] data = new char[16];
     writeHexLong(data, 0, v);
     return new String(data);
   }
 
-  /** Inspired by {@code okio.Buffer.writeLong} */
+  /**
+   * Inspired by {@code okio.Buffer.writeLong}
+   */
   static void writeHexLong(char[] data, int pos, long v) {
     writeHexByte(data, pos + 0, (byte) ((v >>> 56L) & 0xff));
     writeHexByte(data, pos + 2, (byte) ((v >>> 48L) & 0xff));

--- a/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
+++ b/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
@@ -21,21 +21,24 @@
  */
 package com.uber.jaeger.propagation.b3;
 
+import static com.uber.jaeger.propagation.b3.B3TextMapCodec.SPAN_ID_NAME;
+import static com.uber.jaeger.propagation.b3.B3TextMapCodec.TRACE_ID_NAME;
+import static org.junit.Assert.assertEquals;
+
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.TraceData;
-import com.github.kristofa.brave.http.*;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
+import com.github.kristofa.brave.http.HttpClientRequest;
+import com.github.kristofa.brave.http.HttpClientRequestAdapter;
+import com.github.kristofa.brave.http.HttpServerRequest;
+import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import com.uber.jaeger.SpanContext;
 import io.opentracing.propagation.TextMap;
-import org.junit.Test;
-
 import java.net.URI;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static com.uber.jaeger.propagation.b3.B3TextMapCodec.SPAN_ID_NAME;
-import static com.uber.jaeger.propagation.b3.B3TextMapCodec.TRACE_ID_NAME;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class B3TextMapCodecTest {
   static final byte SAMPLED = 1;
@@ -49,9 +52,9 @@ public class B3TextMapCodecTest {
 
     SpanContext context = b3Codec.extract(textMap);
 
-    assertEquals(1, context.getTraceID());
-    assertEquals(0, context.getParentID()); // parentID==0 means root span
-    assertEquals(1, context.getSpanID());
+    assertEquals(1, context.getTraceId());
+    assertEquals(0, context.getParentId()); // parentID==0 means root span
+    assertEquals(1, context.getSpanId());
     assertEquals(1, context.getFlags()); // sampled
   }
 
@@ -66,8 +69,8 @@ public class B3TextMapCodecTest {
 
     SpanContext context = b3Codec.extract(textMap);
 
-    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getTraceID());
-    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getSpanID());
+    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getTraceId());
+    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getSpanId());
   }
 
   @Test
@@ -77,9 +80,9 @@ public class B3TextMapCodecTest {
 
     SpanContext context = b3Codec.extract(textMap);
 
-    assertEquals(1, context.getTraceID());
-    assertEquals(1, context.getParentID());
-    assertEquals(2, context.getSpanID());
+    assertEquals(1, context.getTraceId());
+    assertEquals(1, context.getParentId());
+    assertEquals(2, context.getSpanId());
     assertEquals(1, context.getFlags()); // sampled
   }
 

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/Callable.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/Callable.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import io.opentracing.Span;

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/Runnable.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/Runnable.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import io.opentracing.Span;

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/ThreadLocalTraceContext.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/ThreadLocalTraceContext.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import io.opentracing.Span;
-
 import java.util.EmptyStackException;
 import java.util.Stack;
 

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TraceContext.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TraceContext.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import io.opentracing.Span;

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracedExecutorService.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracedExecutorService.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import java.util.ArrayList;

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.context;
 
 import java.util.concurrent.ExecutorService;

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/CallableTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/CallableTest.java
@@ -21,15 +21,15 @@
  */
 package com.uber.jaeger.context;
 
-import io.opentracing.Span;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
 
 public class CallableTest {
   TraceContext traceContext;

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/RunnableTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/RunnableTest.java
@@ -21,15 +21,15 @@
  */
 package com.uber.jaeger.context;
 
-import io.opentracing.Span;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RunnableTest {
   TraceContext traceContext;

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracedExecutorServiceTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracedExecutorServiceTest.java
@@ -21,15 +21,6 @@
  */
 package com.uber.jaeger.context;
 
-import io.opentracing.Span;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +30,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TracedExecutorServiceTest {
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
 import com.uber.jaeger.metrics.Metrics;
@@ -30,13 +31,12 @@ import com.uber.jaeger.reporters.LoggingReporter;
 import com.uber.jaeger.reporters.RemoteReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.ConstSampler;
-import com.uber.jaeger.samplers.HTTPSamplingManager;
+import com.uber.jaeger.samplers.HttpSamplingManager;
 import com.uber.jaeger.samplers.ProbabilisticSampler;
 import com.uber.jaeger.samplers.RateLimitingSampler;
 import com.uber.jaeger.samplers.RemoteControlledSampler;
 import com.uber.jaeger.samplers.Sampler;
-import com.uber.jaeger.senders.UDPSender;
-
+import com.uber.jaeger.senders.UdpSender;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -92,7 +92,7 @@ public class Configuration {
     return new Tracer.Builder(serviceName, reporter, sampler).withMetrics(metrics);
   }
 
-  synchronized public io.opentracing.Tracer getTracer() {
+  public synchronized io.opentracing.Tracer getTracer() {
     if (tracer != null) {
       return tracer;
     }
@@ -102,7 +102,7 @@ public class Configuration {
     return tracer;
   }
 
-  synchronized public void closeTracer() {
+  public synchronized void closeTracer() {
     if (tracer != null) {
       tracer.close();
     }
@@ -125,7 +125,7 @@ public class Configuration {
    */
   public static class SamplerConfiguration {
 
-    private final static String defaultManagerHostPort = "localhost:5778";
+    private static final String defaultManagerHostPort = "localhost:5778";
 
     /**
      * The type of sampler to use in the tracer. Optional. Valid values: remote (default),
@@ -178,7 +178,7 @@ public class Configuration {
       if (samplerType.equals(RemoteControlledSampler.TYPE)) {
         Sampler initialSampler = new ProbabilisticSampler(samplerParam.doubleValue());
 
-        HTTPSamplingManager manager = new HTTPSamplingManager(hostPort);
+        HttpSamplingManager manager = new HttpSamplingManager(hostPort);
 
         return new RemoteControlledSampler(serviceName, manager, initialSampler, metrics);
       }
@@ -201,10 +201,10 @@ public class Configuration {
 
   public static class ReporterConfiguration {
 
-    private final static String defaultAgentHost = "localhost";
-    private final static int defaultAgentPort = 5775;
-    private final static int defaultFlushIntervalMs = 1000;
-    private final static int defaultMaxQueueSize = 100;
+    private static final String defaultAgentHost = "localhost";
+    private static final int defaultAgentPort = 5775;
+    private static final int defaultFlushIntervalMs = 1000;
+    private static final int defaultMaxQueueSize = 100;
 
     private final Boolean logSpans;
 
@@ -234,8 +234,8 @@ public class Configuration {
     }
 
     private Reporter getReporter(Metrics metrics) {
-      UDPSender sender =
-          new UDPSender(
+      UdpSender sender =
+          new UdpSender(
               stringOrDefault(this.agentHost, defaultAgentHost),
               numberOrDefault(this.agentPort, defaultAgentPort).intValue(),
               0 /* max packet size */);

--- a/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
 public class Constants {

--- a/jaeger-core/src/main/java/com/uber/jaeger/LogData.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/LogData.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
-import lombok.Getter;
-
 import java.util.Map;
+import lombok.Getter;
 
 @Getter
 public final class LogData {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Reference.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Reference.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
 import lombok.Value;
@@ -29,6 +30,6 @@ import lombok.Value;
 @Value
 public class Reference {
 
-    private final SpanContext spanContext;
-    private final String type;
+  private final SpanContext spanContext;
+  private final String type;
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -19,15 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
+import io.opentracing.tag.Tags;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.opentracing.tag.Tags;
 
 public class Span implements io.opentracing.Span {
   private final Tracer tracer;

--- a/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/SpanContext.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger;
 
 import com.uber.jaeger.exceptions.EmptyTracerStateStringException;
@@ -32,33 +33,33 @@ public class SpanContext implements io.opentracing.SpanContext {
   protected static final byte flagSampled = 1;
   protected static final byte flagDebug = 2;
 
-  private final long traceID;
-  private final long spanID;
-  private final long parentID;
+  private final long traceId;
+  private final long spanId;
+  private final long parentId;
   private final byte flags;
   private final Map<String, String> baggage;
-  private final String debugID;
+  private final String debugId;
 
-  public SpanContext(long traceID, long spanID, long parentID, byte flags) {
-    this(traceID, spanID, parentID, flags, Collections.<String, String>emptyMap(), null);
+  public SpanContext(long traceId, long spanId, long parentId, byte flags) {
+    this(traceId, spanId, parentId, flags, Collections.<String, String>emptyMap(), null);
   }
 
   SpanContext(
-      long traceID,
-      long spanID,
-      long parentID,
+      long traceId,
+      long spanId,
+      long parentId,
       byte flags,
       Map<String, String> baggage,
-      String debugID) {
+      String debugId) {
     if (baggage == null) {
       throw new NullPointerException();
     }
-    this.traceID = traceID;
-    this.spanID = spanID;
-    this.parentID = parentID;
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.parentId = parentId;
     this.flags = flags;
     this.baggage = baggage;
-    this.debugID = debugID;
+    this.debugId = debugId;
   }
 
   @Override
@@ -74,16 +75,16 @@ public class SpanContext implements io.opentracing.SpanContext {
     return this.baggage;
   }
 
-  public long getTraceID() {
-    return traceID;
+  public long getTraceId() {
+    return traceId;
   }
 
-  public long getSpanID() {
-    return spanID;
+  public long getSpanId() {
+    return spanId;
   }
 
-  public long getParentID() {
-    return parentID;
+  public long getParentId() {
+    return parentId;
   }
 
   public byte getFlags() {
@@ -100,7 +101,7 @@ public class SpanContext implements io.opentracing.SpanContext {
 
   public String contextAsString() {
     // TODO(oibe) profile, and make sure this is fast enough
-    return String.format("%x:%x:%x:%x", traceID, spanID, parentID, flags);
+    return String.format("%x:%x:%x:%x", traceId, spanId, parentId, flags);
   }
 
   @Override
@@ -133,15 +134,15 @@ public class SpanContext implements io.opentracing.SpanContext {
   public SpanContext withBaggageItem(String key, String val) {
     Map<String, String> newBaggage = new HashMap<String, String>(this.baggage);
     newBaggage.put(key, val);
-    return new SpanContext(traceID, spanID, parentID, flags, newBaggage, debugID);
+    return new SpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
   }
 
   public SpanContext withBaggage(Map<String, String> newBaggage) {
-    return new SpanContext(traceID, spanID, parentID, flags, newBaggage, debugID);
+    return new SpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
   }
 
   public SpanContext withFlags(byte flags) {
-    return new SpanContext(traceID, spanID, parentID, flags, baggage, debugID);
+    return new SpanContext(traceId, spanId, parentId, flags, baggage, debugId);
   }
 
   /**
@@ -149,31 +150,31 @@ public class SpanContext implements io.opentracing.SpanContext {
    * from extract() method. This happens in the situation when "jaeger-debug-id" header is passed in
    * the carrier to the extract() method, but the request otherwise has no span context in it.
    * Previously this would've returned null from the extract method, but now it returns a dummy
-   * context with only debugID filled in.
+   * context with only debugId filled in.
    *
    * @see Constants#DEBUG_ID_HEADER_KEY
    */
-  boolean isDebugIDContainerOnly() {
-    return traceID == 0 && debugID != null;
+  boolean isDebugIdContainerOnly() {
+    return traceId == 0 && debugId != null;
   }
 
   /**
-   * Create a new dummy SpanContext as a container for debugID string. This is used when
+   * Create a new dummy SpanContext as a container for debugId string. This is used when
    * "jaeger-debug-id" header is passed in the request headers and forces the trace to be sampled as
    * debug trace, and the value of header recorded as a span tag to serve as a searchable
    * correlation ID.
    *
-   * @param debugID arbitrary string used as correlation ID
+   * @param debugId arbitrary string used as correlation ID
    *
-   * @return new dummy SpanContext that serves as a container for debugID only.
+   * @return new dummy SpanContext that serves as a container for debugId only.
    *
    * @see Constants#DEBUG_ID_HEADER_KEY
    */
-  public static SpanContext withDebugID(String debugID) {
-    return new SpanContext(0, 0, 0, (byte) 0, Collections.<String, String>emptyMap(), debugID);
+  public static SpanContext withDebugId(String debugId) {
+    return new SpanContext(0, 0, 0, (byte) 0, Collections.<String, String>emptyMap(), debugId);
   }
 
-  String getDebugID() {
-    return debugID;
+  String getDebugId() {
+    return debugId;
   }
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/EmptyIpException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/EmptyIpException.java
@@ -19,10 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
-public class EmptyIPException extends RuntimeException {
-  public EmptyIPException() {
+public class EmptyIpException extends RuntimeException {
+  public EmptyIpException() {
     super("Empty string given for ip");
   }
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/EmptyTracerStateStringException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/EmptyTracerStateStringException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class EmptyTracerStateStringException extends RuntimeException {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/MalformedTracerStateStringException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/MalformedTracerStateStringException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class MalformedTracerStateStringException extends RuntimeException {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/NotFourOctetsException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/NotFourOctetsException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class NotFourOctetsException extends RuntimeException {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/SamplingStrategyErrorException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/SamplingStrategyErrorException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class SamplingStrategyErrorException extends RuntimeException {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/SenderException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/SenderException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class SenderException extends Exception {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/UnknownSamplingStrategyException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/UnknownSamplingStrategyException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 public class UnknownSamplingStrategyException extends Exception {

--- a/jaeger-core/src/main/java/com/uber/jaeger/exceptions/UnsupportedFormatException.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/exceptions/UnsupportedFormatException.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.exceptions;
 
 import io.opentracing.propagation.Format;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Counter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Counter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 public interface Counter {

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Gauge.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Gauge.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 public interface Gauge {

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/InMemoryStatsReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/InMemoryStatsReporter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.util.HashMap;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metric.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metric.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.lang.annotation.ElementType;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.lang.annotation.Annotation;
@@ -99,57 +100,57 @@ public class Metrics {
   }
 
   @Metric(
-    name = "traces",
-    tags = {@Tag(key = "state", value = "started"), @Tag(key = "sampled", value = "y")}
+      name = "traces",
+      tags = {@Tag(key = "state", value = "started"), @Tag(key = "sampled", value = "y")}
   )
   // Number of traces started by this tracer as sampled
   public Counter traceStartedSampled;
 
   @Metric(
-    name = "traces",
-    tags = {@Tag(key = "state", value = "started"), @Tag(key = "sampled", value = "n")}
+      name = "traces",
+      tags = {@Tag(key = "state", value = "started"), @Tag(key = "sampled", value = "n")}
   )
   // Number of traces started by this tracer as not sampled
   public Counter traceStartedNotSampled;
 
   @Metric(
-    name = "traces",
-    tags = {@Tag(key = "state", value = "joined"), @Tag(key = "sampled", value = "y")}
+      name = "traces",
+      tags = {@Tag(key = "state", value = "joined"), @Tag(key = "sampled", value = "y")}
   )
   // Number of externally started sampled traces this tracer joined
   public Counter tracesJoinedSampled;
 
   @Metric(
-    name = "traces",
-    tags = {@Tag(key = "state", value = "joined"), @Tag(key = "sampled", value = "n")}
+      name = "traces",
+      tags = {@Tag(key = "state", value = "joined"), @Tag(key = "sampled", value = "n")}
   )
   // Number of externally started not-sampled traces this tracer joined
   public Counter tracesJoinedNotSampled;
 
   @Metric(
-    name = "spans",
-    tags = {@Tag(key = "state", value = "started"), @Tag(key = "group", value = "lifecycle")}
+      name = "spans",
+      tags = {@Tag(key = "state", value = "started"), @Tag(key = "group", value = "lifecycle")}
   )
   // Number of sampled spans started by this tracer
   public Counter spansStarted;
 
   @Metric(
-    name = "spans",
-    tags = {@Tag(key = "state", value = "finished"), @Tag(key = "group", value = "lifecycle")}
+      name = "spans",
+      tags = {@Tag(key = "state", value = "finished"), @Tag(key = "group", value = "lifecycle")}
   )
   // Number of sampled spans started by this tracer
   public Counter spansFinished;
 
   @Metric(
-    name = "spans",
-    tags = {@Tag(key = "group", value = "sampling"), @Tag(key = "sampled", value = "y")}
+      name = "spans",
+      tags = {@Tag(key = "group", value = "sampling"), @Tag(key = "sampled", value = "y")}
   )
   // Number of sampled spans started by this tracer
   public Counter spansSampled;
 
   @Metric(
-    name = "spans",
-    tags = {@Tag(key = "group", value = "sampling"), @Tag(key = "sampled", value = "n")}
+      name = "spans",
+      tags = {@Tag(key = "group", value = "sampling"), @Tag(key = "sampled", value = "n")}
   )
   // Number of not-sampled spans started by this tracer
   public Counter spansNotSampled;
@@ -159,22 +160,22 @@ public class Metrics {
   public Counter decodingErrors;
 
   @Metric(
-    name = "reporter-spans",
-    tags = {@Tag(key = "state", value = "success")}
+      name = "reporter-spans",
+      tags = {@Tag(key = "state", value = "success")}
   )
   // Number of spans successfully reported
   public Counter reporterSuccess;
 
   @Metric(
-    name = "reporter-spans",
-    tags = {@Tag(key = "state", value = "failure")}
+      name = "reporter-spans",
+      tags = {@Tag(key = "state", value = "failure")}
   )
   // Number of spans in failed attempts to report
   public Counter reporterFailure;
 
   @Metric(
-    name = "spans",
-    tags = {@Tag(key = "state", value = "dropped")}
+      name = "spans",
+      tags = {@Tag(key = "state", value = "dropped")}
   )
   // Number of spans dropped due to internal queue overflow
   public Counter reporterDropped;
@@ -184,31 +185,29 @@ public class Metrics {
   public Gauge reporterQueueLength;
 
   @Metric(
-    name = "sampler",
-    tags = {@Tag(key = "state", value = "retrieved")}
+      name = "sampler",
+      tags = {@Tag(key = "state", value = "retrieved")}
   )
   // Number of times the Sampler succeeded to retrieve samping strategy
   public Counter samplerRetrieved;
 
   @Metric(
-    name = "sampler",
-    tags = {
-      @Tag(key = "state", value = "updated"),
-    }
+      name = "sampler",
+      tags = {@Tag(key = "state", value = "updated")}
   )
   // Number of times the Sampler succeeded to retrieve and updateGauge sampling strategy
   public Counter samplerUpdated;
 
   @Metric(
-    name = "sampler",
-    tags = {@Tag(key = "state", value = "failure"), @Tag(key = "phase", value = "query")}
+      name = "sampler",
+      tags = {@Tag(key = "state", value = "failure"), @Tag(key = "phase", value = "query")}
   )
   // Number of times the Sampler failed to retrieve the sampling strategy
   public Counter samplerQueryFailure;
 
   @Metric(
-    name = "sampler",
-    tags = {@Tag(key = "state", value = "failure"), @Tag(key = "phase", value = "parsing")}
+      name = "sampler",
+      tags = {@Tag(key = "state", value = "failure"), @Tag(key = "phase", value = "parsing")}
   )
   // Number of times the Sampler failed to parse retrieved sampling strategy
   public Counter samplerParsingFailure;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/NullStatsReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/NullStatsReporter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.util.Map;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsFactory.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsFactory.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.util.Map;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsFactoryImpl.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsFactoryImpl.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.util.Map;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/StatsReporter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.util.Map;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Tag.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Tag.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 import java.lang.annotation.ElementType;

--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Timer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Timer.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.metrics;
 
 public interface Timer {

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/Extractor.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/Extractor.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation;
 
 import com.uber.jaeger.SpanContext;

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/Injector.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/Injector.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation;
 
 import com.uber.jaeger.SpanContext;

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/PrefixedKeys.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/PrefixedKeys.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation;
 
 // TODO profile and cache prefixed and unprefixed keys if necessary

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
@@ -19,24 +19,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.propagation;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.SpanContext;
-
+import io.opentracing.propagation.TextMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.opentracing.propagation.TextMap;
-
 public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
-  /** Key used to store serialized span context representation */
+  /**
+   * Key used to store serialized span context representation
+   */
   private static final String SPAN_CONTEXT_KEY = "uber-trace-id";
 
-  /** Key prefix used for baggage items */
+  /**
+   * Key prefix used for baggage items
+   */
   private static final String BAGGAGE_KEY_PREFIX = "uberctx-";
 
   private static final PrefixedKeys keys = new PrefixedKeys();
@@ -48,7 +51,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   private final boolean urlEncoding;
 
   public TextMapCodec(boolean urlEncoding) {
-    this(builder().withURLEncoding(urlEncoding));
+    this(builder().withUrlEncoding(urlEncoding));
   }
 
   private TextMapCodec(Builder builder) {
@@ -69,14 +72,14 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   public SpanContext extract(TextMap carrier) {
     SpanContext context = null;
     Map<String, String> baggage = null;
-    String debugID = null;
+    String debugId = null;
     for (Map.Entry<String, String> entry : carrier) {
       // TODO there should be no lower-case here
       String key = entry.getKey().toLowerCase();
       if (key.equals(contextKey)) {
         context = SpanContext.contextFromString(decodedValue(entry.getValue()));
       } else if (key.equals(Constants.DEBUG_ID_HEADER_KEY)) {
-        debugID = decodedValue(entry.getValue());
+        debugId = decodedValue(entry.getValue());
       } else if (key.startsWith(baggagePrefix)) {
         if (baggage == null) {
           baggage = new HashMap<String, String>();
@@ -85,8 +88,8 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
       }
     }
     if (context == null) {
-      if (debugID != null) {
-        return SpanContext.withDebugID(debugID);
+      if (debugId != null) {
+        return SpanContext.withDebugId(debugId);
       }
       return null;
     }
@@ -138,7 +141,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   }
 
   /**
-   * Returns a builder for TextMapCodec
+   * Returns a builder for TextMapCodec.
    *
    * @return Builder
    */
@@ -152,7 +155,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
     private String spanContextKey = SPAN_CONTEXT_KEY;
     private String baggagePrefix = BAGGAGE_KEY_PREFIX;
 
-    public Builder withURLEncoding(boolean urlEncoding) {
+    public Builder withUrlEncoding(boolean urlEncoding) {
       this.urlEncoding = urlEncoding;
       return this;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/CompositeReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/CompositeReporter.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;
-
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/InMemoryReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/InMemoryReporter.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;
-
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/LoggingReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/LoggingReporter.java
@@ -19,13 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import lombok.ToString;
 
 /**
  * LoggingReporter logs every span it's given.

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/NoopReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/NoopReporter.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;
-
 import lombok.ToString;
 
 @ToString

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
@@ -19,18 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.reporters;
 
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.metrics.Metrics;
 import com.uber.jaeger.senders.Sender;
-
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/Reporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/Reporter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.Span;

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverter.java
@@ -19,11 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.reporters.protocols;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+package com.uber.jaeger.reporters.protocols;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.LogData;
@@ -35,8 +32,10 @@ import com.uber.jaeger.thriftjava.SpanRef;
 import com.uber.jaeger.thriftjava.SpanRefType;
 import com.uber.jaeger.thriftjava.Tag;
 import com.uber.jaeger.thriftjava.TagType;
-
 import io.opentracing.References;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class JaegerThriftSpanConverter {
 
@@ -46,10 +45,10 @@ public class JaegerThriftSpanConverter {
     SpanContext context = span.context();
 
     return new com.uber.jaeger.thriftjava.Span(
-            context.getTraceID(),
+            context.getTraceId(),
             0, // TraceIdHigh is currently not supported
-            context.getSpanID(),
-            context.getParentID(),
+            context.getSpanId(),
+            context.getParentId(),
             span.getOperationName(),
             context.getFlags(),
             span.getStart(),
@@ -64,21 +63,21 @@ public class JaegerThriftSpanConverter {
     for (Reference reference: references) {
       SpanRefType thriftRefType = References.CHILD_OF.equals(reference.getType()) ? SpanRefType.CHILD_OF :
               SpanRefType.FOLLOWS_FROM;
-      thriftReferences.add(new SpanRef(thriftRefType, reference.getSpanContext().getTraceID(),
-              0, reference.getSpanContext().getSpanID()));
+      thriftReferences.add(new SpanRef(thriftRefType, reference.getSpanContext().getTraceId(),
+              0, reference.getSpanContext().getSpanId()));
     }
 
     return thriftReferences;
   }
 
   static List<Log> buildLogs(List<LogData> logs) {
-    List<Log> jLogs = new ArrayList<Log>();
+    List<Log> thriftLogs = new ArrayList<Log>();
     if (logs != null) {
       for (LogData logData : logs) {
-        Log jLog = new Log();
-        jLog.setTimestamp(logData.getTime());
+        Log thriftLog = new Log();
+        thriftLog.setTimestamp(logData.getTime());
         if (logData.getFields() != null) {
-          jLog.setFields(buildTags(logData.getFields()));
+          thriftLog.setFields(buildTags(logData.getFields()));
         } else {
           List<Tag> tags = new ArrayList<Tag>();
           if (logData.getMessage() != null) {
@@ -87,24 +86,24 @@ public class JaegerThriftSpanConverter {
           if (logData.getPayload() != null) {
             tags.add(buildTag("payload", logData.getPayload()));
           }
-          jLog.setFields(tags);
+          thriftLog.setFields(tags);
         }
-        jLogs.add(jLog);
+        thriftLogs.add(thriftLog);
       }
     }
-    return jLogs;
+    return thriftLogs;
   }
 
   public static List<Tag> buildTags(Map<String, ?> tags) {
-    List<Tag> jTags = new ArrayList<Tag>();
+    List<Tag> thriftTags = new ArrayList<Tag>();
     if (tags != null) {
       for (Map.Entry<String, ?> entry : tags.entrySet()) {
         String tagKey = entry.getKey();
         Object tagValue = entry.getValue();
-        jTags.add(buildTag(tagKey, tagValue));
+        thriftTags.add(buildTag(tagKey, tagValue));
       }
     }
-    return jTags;
+    return thriftTags;
   }
 
   static Tag buildTag(String tagKey, Object tagValue) {

--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/ThriftUdpTransport.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/protocols/ThriftUdpTransport.java
@@ -19,10 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.reporters.protocols;
 
-import org.apache.thrift.transport.TTransport;
-import org.apache.thrift.transport.TTransportException;
+package com.uber.jaeger.reporters.protocols;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,14 +30,15 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-
 import lombok.ToString;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 
 /*
  * A thrift transport for sending sending/receiving spans.
  */
 @ToString(exclude = {"writeBuffer"})
-public class TUDPTransport extends TTransport implements Closeable {
+public class ThriftUdpTransport extends TTransport implements Closeable {
   public static final int MAX_PACKET_SIZE = 65000;
 
   public final DatagramSocket socket;
@@ -49,10 +48,10 @@ public class TUDPTransport extends TTransport implements Closeable {
   public ByteBuffer writeBuffer;
 
   // Create a UDP client for sending data to specific host and port
-  public static TUDPTransport NewTUDPClient(String host, int port) {
-    TUDPTransport t;
+  public static ThriftUdpTransport newThriftUdpClient(String host, int port) {
+    ThriftUdpTransport t;
     try {
-      t = new TUDPTransport();
+      t = new ThriftUdpTransport();
       t.socket.connect(new InetSocketAddress(host, port));
     } catch (SocketException e) {
       throw new RuntimeException("TUDPTransport cannot connect: ", e);
@@ -61,14 +60,14 @@ public class TUDPTransport extends TTransport implements Closeable {
   }
 
   // Create a UDP server for receiving data on specific host and port
-  public static TUDPTransport NewTUDPServer(String host, int port)
+  public static ThriftUdpTransport newThriftUdpServer(String host, int port)
       throws SocketException, UnknownHostException {
-    TUDPTransport t = new TUDPTransport();
+    ThriftUdpTransport t = new ThriftUdpTransport();
     t.socket.bind(new InetSocketAddress(host, port));
     return t;
   }
 
-  private TUDPTransport() throws SocketException {
+  private ThriftUdpTransport() throws SocketException {
     this.socket = new DatagramSocket(null);
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ConstSampler.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.Constants;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,7 +57,9 @@ public class ConstSampler implements Sampler {
 
   @Override
   public boolean equals(Object other) {
-    if (this == other) return true;
+    if (this == other) {
+      return true;
+    }
     if (other instanceof ConstSampler) {
       return this.decision == ((ConstSampler) other).decision;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/GuaranteedThroughputSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/GuaranteedThroughputSampler.java
@@ -19,18 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.Constants;
-import com.uber.jaeger.samplers.http.OperationSamplingParameters;
-import com.uber.jaeger.samplers.http.PerOperationSamplingParameters;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * {@link GuaranteedThroughputSampler} is a {@link Sampler} that guarantees a throughput by using

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/HttpSamplingManager.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/HttpSamplingManager.java
@@ -19,14 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-
 import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
 import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -34,16 +33,15 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-
 import lombok.ToString;
 
 @ToString
-public class HTTPSamplingManager implements SamplingManager {
+public class HttpSamplingManager implements SamplingManager {
   private static final String defaultSamplingServerHostPort = "localhost:5778";
   private String hostPort = defaultSamplingServerHostPort;
   private Gson gson = new Gson();
 
-  public HTTPSamplingManager(String hostPort) {
+  public HttpSamplingManager(String hostPort) {
     if (hostPort != null) {
       this.hostPort = hostPort;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/PerOperationSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/PerOperationSampler.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.samplers.http.OperationSamplingParameters;
 import com.uber.jaeger.samplers.http.PerOperationSamplingParameters;
-
 import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/ProbabilisticSampler.java
@@ -19,10 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.Constants;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -72,7 +72,9 @@ public class ProbabilisticSampler implements Sampler {
 
   @Override
   public boolean equals(Object other) {
-    if (this == other) return true;
+    if (this == other) {
+      return true;
+    }
     if (other instanceof ProbabilisticSampler) {
       return this.samplingRate == ((ProbabilisticSampler) other).samplingRate;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RateLimitingSampler.java
@@ -19,15 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.utils.RateLimiter;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import lombok.Getter;
 import lombok.ToString;
 
@@ -59,7 +58,9 @@ public class RateLimitingSampler implements Sampler {
 
   @Override
   public boolean equals(Object other) {
-    if (this == other) return true;
+    if (this == other) {
+      return true;
+    }
     if (other instanceof RateLimitingSampler) {
       return this.maxTracesPerSecond == ((RateLimitingSampler) other).maxTracesPerSecond;
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/RemoteControlledSampler.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.exceptions.SamplingStrategyErrorException;
@@ -27,7 +28,6 @@ import com.uber.jaeger.samplers.http.OperationSamplingParameters;
 import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
 import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
 import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
-
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -152,7 +152,9 @@ public class RemoteControlledSampler implements Sampler {
 
   @Override
   public boolean equals(Object sampler) {
-    if (this == sampler) return true;
+    if (this == sampler) {
+      return true;
+    }
     if (sampler instanceof RemoteControlledSampler) {
       RemoteControlledSampler remoteSampler = ((RemoteControlledSampler) sampler);
       synchronized (this) {

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/Sampler.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 /**

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingManager.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingManager.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import com.uber.jaeger.exceptions.SamplingStrategyErrorException;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingStatus.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/SamplingStatus.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers;
 
 import java.util.Map;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/OperationSamplingParameters.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/OperationSamplingParameters.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers.http;
 
 import java.util.List;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/PerOperationSamplingParameters.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/PerOperationSamplingParameters.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers.http;
 
 import lombok.Value;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/ProbabilisticSamplingStrategy.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/ProbabilisticSamplingStrategy.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers.http;
 
 import lombok.Value;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/RateLimitingSamplingStrategy.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/RateLimitingSamplingStrategy.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers.http;
 
 import lombok.Value;

--- a/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyResponse.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/samplers/http/SamplingStrategyResponse.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.samplers.http;
 
 import lombok.Value;

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/Sender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/Sender.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.senders;
 
 import com.uber.jaeger.Span;

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
@@ -19,13 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.senders;
 
 import com.uber.jaeger.Span;
 import com.uber.jaeger.agent.thrift.Agent;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.reporters.protocols.JaegerThriftSpanConverter;
-import com.uber.jaeger.reporters.protocols.TUDPTransport;
+import com.uber.jaeger.reporters.protocols.ThriftUdpTransport;
 import com.uber.jaeger.thriftjava.Batch;
 import com.uber.jaeger.thriftjava.Process;
 import java.util.ArrayList;
@@ -37,8 +38,8 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 
 @ToString(exclude = {"spanBuffer", "udpClient", "memoryTransport"})
-public class UDPSender implements Sender {
-  final static int emitBatchOverhead = 33;
+public class UdpSender implements Sender {
+  static final int emitBatchOverhead = 33;
   private static final String defaultUDPSpanServerHost = "localhost";
   private static final int defaultUDPSpanServerPort = 6832;
   private static final int defaultUDPPacketSize = 65000;
@@ -48,11 +49,11 @@ public class UDPSender implements Sender {
   private List<com.uber.jaeger.thriftjava.Span> spanBuffer;
   private int byteBufferSize;
   private AutoExpandingBufferWriteTransport memoryTransport;
-  private TUDPTransport udpTransport;
+  private ThriftUdpTransport udpTransport;
   private Process process;
   private int processBytesSize;
 
-  public UDPSender(String host, int port, int maxPacketSize) {
+  public UdpSender(String host, int port, int maxPacketSize) {
     if (host == null || host.length() == 0) {
       host = defaultUDPSpanServerHost;
     }
@@ -67,7 +68,7 @@ public class UDPSender implements Sender {
 
     memoryTransport = new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
 
-    udpTransport = TUDPTransport.NewTUDPClient(host, port);
+    udpTransport = ThriftUdpTransport.newThriftUdpClient(host, port);
     udpClient = new Agent.Client(new TCompactProtocol(udpTransport));
     maxSpanBytes = maxPacketSize - emitBatchOverhead;
     spanBuffer = new ArrayList<com.uber.jaeger.thriftjava.Span>();

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Clock.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Clock.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.utils;
 
 /**

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandom.java
@@ -19,12 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.utils;
 
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+package com.uber.jaeger.utils;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 public final class Java6CompatibleThreadLocalRandom {
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/RateLimiter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.utils;
 
 public class RateLimiter {

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/SystemClock.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/SystemClock.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.utils;
 
 /**

--- a/jaeger-core/src/main/java/com/uber/jaeger/utils/Utils.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/utils/Utils.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.utils;
 
-import com.uber.jaeger.exceptions.EmptyIPException;
+import com.uber.jaeger.exceptions.EmptyIpException;
 import com.uber.jaeger.exceptions.NotFourOctetsException;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -32,9 +32,9 @@ public class Utils {
     return key.replaceAll("_", "-").toLowerCase();
   }
 
-  public static int ipToInt(String ip) throws EmptyIPException, NotFourOctetsException {
+  public static int ipToInt(String ip) throws EmptyIpException, NotFourOctetsException {
     if (ip.equals("")) {
-      throw new EmptyIPException();
+      throw new EmptyIpException();
     }
 
     if (ip.equals("localhost")) {
@@ -48,14 +48,14 @@ public class Utils {
       throw new NotFourOctetsException();
     }
 
-    int intIP = 0;
+    int intIp = 0;
     for (byte octet : octets.getAddress()) {
-      intIP = (intIP << 8) | (octet);
+      intIp = (intIp << 8) | (octet);
     }
-    return intIP;
+    return intIp;
   }
 
-  public static long uniqueID() {
+  public static long uniqueId() {
     long val = 0;
     while (val == 0) {
       val = Java6CompatibleThreadLocalRandom.current().nextLong();

--- a/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
@@ -21,18 +21,17 @@
  */
 package com.uber.jaeger;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.propagation.TextMapExtractAdapter;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class PropagationTest {
   @Test
@@ -43,8 +42,8 @@ public class PropagationTest {
     headers.put(Constants.DEBUG_ID_HEADER_KEY, "Coraline");
     TextMap carrier = new TextMapExtractAdapter(headers);
     SpanContext spanContext = (SpanContext) tracer.extract(Format.Builtin.TEXT_MAP, carrier);
-    assertTrue(spanContext.isDebugIDContainerOnly());
-    assertEquals("Coraline", spanContext.getDebugID());
+    assertTrue(spanContext.isDebugIdContainerOnly());
+    assertEquals("Coraline", spanContext.getDebugId());
     Span span = (Span) tracer.buildSpan("span").asChildOf(spanContext).start();
     spanContext = (SpanContext) span.context();
     assertTrue(spanContext.isSampled());

--- a/jaeger-core/src/test/java/com/uber/jaeger/SpanContextTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/SpanContextTest.java
@@ -42,9 +42,9 @@ public class SpanContextTest {
   @Test
   public void testContextFromString() throws Exception {
     SpanContext context = SpanContext.contextFromString("ff:dd:cc:4");
-    assertEquals(context.getTraceID(), 255);
-    assertEquals(context.getSpanID(), 221);
-    assertEquals(context.getParentID(), 204);
+    assertEquals(context.getTraceId(), 255);
+    assertEquals(context.getSpanId(), 221);
+    assertEquals(context.getParentId(), 204);
     assertEquals(context.getFlags(), 4);
   }
 
@@ -64,9 +64,9 @@ public class SpanContextTest {
     assertEquals(
         "fffffffffffffff6:fffffffffffffff6:fffffffffffffff6:81", context.contextAsString());
     SpanContext contextFromStr = SpanContext.contextFromString(context.contextAsString());
-    assertEquals(traceID, contextFromStr.getTraceID());
-    assertEquals(spanID, contextFromStr.getSpanID());
-    assertEquals(parentID, contextFromStr.getParentID());
+    assertEquals(traceID, contextFromStr.getTraceId());
+    assertEquals(spanID, contextFromStr.getSpanId());
+    assertEquals(parentID, contextFromStr.getParentId());
     assertEquals(flags, contextFromStr.getFlags());
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/SpanTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/SpanTest.java
@@ -27,20 +27,17 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.uber.jaeger.metrics.InMemoryStatsReporter;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.utils.Clock;
 import io.opentracing.tag.Tags;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
-
+import org.junit.Before;
+import org.junit.Test;
 
 public class SpanTest {
   private Clock clock;
@@ -178,9 +175,9 @@ public class SpanTest {
     SpanContext expectedContext = span.context();
     SpanContext actualContext = SpanContext.contextFromString(span.context().contextAsString());
 
-    assertEquals(expectedContext.getTraceID(), actualContext.getTraceID());
-    assertEquals(expectedContext.getSpanID(), actualContext.getSpanID());
-    assertEquals(expectedContext.getParentID(), actualContext.getParentID());
+    assertEquals(expectedContext.getTraceId(), actualContext.getTraceId());
+    assertEquals(expectedContext.getSpanId(), actualContext.getSpanId());
+    assertEquals(expectedContext.getParentId(), actualContext.getParentId());
     assertEquals(expectedContext.getFlags(), actualContext.getFlags());
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
@@ -24,21 +24,18 @@ package com.uber.jaeger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.uber.jaeger.reporters.InMemoryReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.tag.Tags;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import com.uber.jaeger.reporters.InMemoryReporter;
-import com.uber.jaeger.samplers.ConstSampler;
-
-import io.opentracing.tag.Tags;
 
 @RunWith(Parameterized.class)
 public class TracerTagsTest {
@@ -106,7 +103,7 @@ public class TracerTagsTest {
   public void testTracerTagsZipkin() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
     Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true))
-            .withZipkinSharedRPCSpan()
+            .withZipkinSharedRpcSpan()
             .withTag("tracer.tag.str", "y")
             .withTag("tracer.tag.bool", true)
             .withTag("tracer.tag.num", 1)

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -28,19 +28,20 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import com.uber.jaeger.metrics.InMemoryStatsReporter;
 import com.uber.jaeger.propagation.Injector;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.samplers.Sampler;
-
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
 
 public class TracerTest {
 
@@ -109,7 +110,7 @@ public class TracerTest {
     Tracer.SpanBuilder spanBuilder = (Tracer.SpanBuilder) tracer.buildSpan("ndnd");
     spanBuilder.withTag(Tags.SPAN_KIND.getKey(), "server");
 
-    assertTrue(spanBuilder.isRPCServer());
+    assertTrue(spanBuilder.isRpcServer());
   }
 
   @Test
@@ -117,7 +118,7 @@ public class TracerTest {
     Tracer.SpanBuilder spanBuilder = (Tracer.SpanBuilder) tracer.buildSpan("Lrrr");
     spanBuilder.withTag(Tags.SPAN_KIND.getKey(), "peachy");
 
-    assertFalse(spanBuilder.isRPCServer());
+    assertFalse(spanBuilder.isRpcServer());
   }
 
   @Test

--- a/jaeger-core/src/test/java/com/uber/jaeger/UtilsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/UtilsTest.java
@@ -21,12 +21,12 @@
  */
 package com.uber.jaeger;
 
-import com.uber.jaeger.exceptions.EmptyIPException;
+import static org.junit.Assert.assertEquals;
+
+import com.uber.jaeger.exceptions.EmptyIpException;
 import com.uber.jaeger.exceptions.NotFourOctetsException;
 import com.uber.jaeger.utils.Utils;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class UtilsTest {
 
@@ -42,7 +42,7 @@ public class UtilsTest {
     Utils.ipToInt(":19");
   }
 
-  @Test(expected = EmptyIPException.class)
+  @Test(expected = EmptyIpException.class)
   public void testIPToInt32EmptyIPException() {
     Utils.ipToInt("");
   }

--- a/jaeger-core/src/test/java/com/uber/jaeger/metrics/MetricsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/metrics/MetricsTest.java
@@ -21,11 +21,11 @@
  */
 package com.uber.jaeger.metrics;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class MetricsTest {
   InMemoryStatsReporter metricsReporter;

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -31,7 +31,7 @@ public class TextMapCodecTest {
     @Test
     public void testBuilder()  {
         TextMapCodec codec = TextMapCodec.builder()
-                .withURLEncoding(true)
+                .withUrlEncoding(true)
                 .withSpanContextKey("jaeger-trace-id")
                 .withBaggagePrefix("jaeger-baggage-")
                 .build();

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/InMemorySender.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/InMemorySender.java
@@ -19,15 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.reporters;
 
-import java.util.ArrayList;
-import java.util.List;
+package com.uber.jaeger.reporters;
 
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.reporters.protocols.JaegerThriftSpanConverter;
 import com.uber.jaeger.senders.Sender;
 import com.uber.jaeger.thriftjava.Span;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InMemorySender implements Sender {
   private List<Span> appended;

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -25,17 +25,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.uber.jaeger.Span;
 import com.uber.jaeger.Tracer;
 import com.uber.jaeger.metrics.InMemoryStatsReporter;
 import com.uber.jaeger.metrics.Metrics;
 import com.uber.jaeger.metrics.StatsFactoryImpl;
 import com.uber.jaeger.samplers.ConstSampler;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RemoteReporterTest {
   private Reporter reporter;

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/InMemorySpanServerHandler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/InMemorySpanServerHandler.java
@@ -21,14 +21,12 @@
  */
 package com.uber.jaeger.reporters.protocols;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.thrift.TException;
-
 import com.twitter.zipkin.thriftjava.Span;
 import com.uber.jaeger.agent.thrift.Agent;
 import com.uber.jaeger.thriftjava.Batch;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.thrift.TException;
 
 class InMemorySpanServerHandler implements Agent.Iface {
   private List<Span> zipkinSpans;

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverterTest.java
@@ -24,15 +24,6 @@ package com.uber.jaeger.reporters.protocols;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -42,8 +33,14 @@ import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.thriftjava.Log;
 import com.uber.jaeger.thriftjava.Tag;
 import com.uber.jaeger.thriftjava.TagType;
-
 import io.opentracing.Span;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)
 public class JaegerThriftSpanConverterTest {

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/TUDPServerTransport.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/TUDPServerTransport.java
@@ -21,18 +21,17 @@
  */
 package com.uber.jaeger.reporters.protocols;
 
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
-import java.net.SocketException;
-import java.net.UnknownHostException;
-
 public class TUDPServerTransport extends TServerTransport {
-  private TUDPTransport transport;
+  private ThriftUdpTransport transport;
 
   public TUDPServerTransport(int localPort) throws SocketException, UnknownHostException {
-    transport = TUDPTransport.NewTUDPServer("localhost", localPort);
+    transport = ThriftUdpTransport.newThriftUdpServer("localhost", localPort);
   }
 
   int getPort() {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/GuaranteedThroughputSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/GuaranteedThroughputSamplerTest.java
@@ -26,12 +26,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.uber.jaeger.Constants;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GuaranteedThroughputSamplerTest {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/HttpSamplingManagerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/HttpSamplingManagerTest.java
@@ -31,10 +31,6 @@ import com.uber.jaeger.samplers.http.PerOperationSamplingParameters;
 import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
 import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
 import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
-
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
@@ -42,10 +38,13 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.List;
 import javax.ws.rs.core.Application;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
 
-public class HTTPSamplingManagerTest extends JerseyTest {
+public class HttpSamplingManagerTest extends JerseyTest {
 
-  HTTPSamplingManager undertest = new HTTPSamplingManager(null);
+  HttpSamplingManager undertest = new HttpSamplingManager(null);
 
   @Override
   protected Application configure() {
@@ -55,7 +54,7 @@ public class HTTPSamplingManagerTest extends JerseyTest {
   @Test
   public void testGetSamplingStrategy() throws Exception {
     URI uri = target().getUri();
-    undertest = new HTTPSamplingManager(uri.getHost() + ":" + uri.getPort());
+    undertest = new HttpSamplingManager(uri.getHost() + ":" + uri.getPort());
     SamplingStrategyResponse response = undertest.getSamplingStrategy("clairvoyant");
     assertNotNull(response.getProbabilisticSampling());
   }
@@ -63,7 +62,7 @@ public class HTTPSamplingManagerTest extends JerseyTest {
   @Test (expected = SamplingStrategyErrorException.class)
   public void testGetSamplingStrategyError() throws Exception {
     URI uri = target().getUri();
-    undertest = new HTTPSamplingManager(uri.getHost() + ":" + uri.getPort());
+    undertest = new HttpSamplingManager(uri.getHost() + ":" + uri.getPort());
     undertest.getSamplingStrategy("");
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/MockAgentResource.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/MockAgentResource.java
@@ -21,7 +21,11 @@
  */
 package com.uber.jaeger.samplers;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
 @Path("")

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/PerOperationSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/PerOperationSamplerTest.java
@@ -33,16 +33,15 @@ import static org.mockito.Mockito.when;
 import com.uber.jaeger.samplers.http.OperationSamplingParameters;
 import com.uber.jaeger.samplers.http.PerOperationSamplingParameters;
 import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PerOperationSamplerTest {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/ProbabilisticSamplerTest.java
@@ -25,9 +25,8 @@ import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-
 import java.util.Map;
+import org.junit.Test;
 
 public class ProbabilisticSamplerTest {
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
@@ -36,15 +36,14 @@ import com.uber.jaeger.samplers.http.PerOperationSamplingParameters;
 import com.uber.jaeger.samplers.http.ProbabilisticSamplingStrategy;
 import com.uber.jaeger.samplers.http.RateLimitingSamplingStrategy;
 import com.uber.jaeger.samplers.http.SamplingStrategyResponse;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteControlledSamplerTest {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestConstSampler.java
@@ -23,9 +23,8 @@ package com.uber.jaeger.samplers;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import java.util.Map;
+import org.junit.Test;
 
 public class TestConstSampler {
   @Test

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/TestRateLimitingSampler.java
@@ -23,9 +23,8 @@ package com.uber.jaeger.samplers;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import java.util.Map;
+import org.junit.Test;
 
 public class TestRateLimitingSampler {
   @Test

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
@@ -44,7 +44,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UDPSenderTest {
+public class UdpSenderTest {
   final static String SERVICE_NAME = "test-sender";
   final String destHost = "localhost";
   int destPort;
@@ -53,7 +53,7 @@ public class UDPSenderTest {
 
   Tracer tracer;
   Reporter reporter;
-  UDPSender sender;
+  UdpSender sender;
   TestTServer server;
 
   private TestTServer startServer() throws Exception {
@@ -76,7 +76,7 @@ public class UDPSenderTest {
             .withStatsReporter(new InMemoryStatsReporter())
             .withTag("foo", "bar")
             .build();
-    sender = new UDPSender(destHost, destPort, maxPacketSize);
+    sender = new UdpSender(destHost, destPort, maxPacketSize);
   }
 
   @After
@@ -128,7 +128,7 @@ public class UDPSenderTest {
     int maxPacketSize = (spanSize * expectedNumSpans) + sender.emitBatchOverhead + processSize;
     int maxPacketSizeLeft = maxPacketSize - sender.emitBatchOverhead - processSize;
     // add enough spans to be under buffer limit
-    sender = new UDPSender(destHost, destPort, maxPacketSize);
+    sender = new UdpSender(destHost, destPort, maxPacketSize);
     while (spanSize < maxPacketSizeLeft) {
       sender.append(jaegerSpan);
       maxPacketSizeLeft -= spanSize;
@@ -154,9 +154,9 @@ public class UDPSenderTest {
     assertEquals(batch.getSpans().size(), expectedNumSpans);
 
     com.uber.jaeger.thriftjava.Span actualSpan = batch.getSpans().get(0);
-    assertEquals(expectedSpan.context().getTraceID(), actualSpan.getTraceIdLow());
+    assertEquals(expectedSpan.context().getTraceId(), actualSpan.getTraceIdLow());
     assertEquals(0, actualSpan.getTraceIdHigh());
-    assertEquals(expectedSpan.context().getSpanID(), actualSpan.getSpanId());
+    assertEquals(expectedSpan.context().getSpanId(), actualSpan.getSpanId());
     assertEquals(0, actualSpan.getParentSpanId());
     assertTrue(actualSpan.references.isEmpty());
     assertEquals(expectedSpan.getOperationName(), actualSpan.getOperationName());
@@ -175,7 +175,7 @@ public class UDPSenderTest {
     // If this test breaks it means we have changed our protocol, or
     // the protocol information has changed (likely due to a new version of thrift).
     assertEquals(a, b);
-    assertEquals(b, UDPSender.emitBatchOverhead);
+    assertEquals(b, UdpSender.emitBatchOverhead);
   }
 
   private int calculateBatchOverheadDifference(int numberOfSpans) throws Exception {

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/Java6CompatibleThreadLocalRandomTest.java
@@ -21,17 +21,16 @@
  */
 package com.uber.jaeger.utils;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class Java6CompatibleThreadLocalRandomTest {
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/utils/RateLimiterTest.java
@@ -21,12 +21,11 @@
  */
 package com.uber.jaeger.utils;
 
-import org.junit.Test;
-
-import java.util.concurrent.TimeUnit;
-
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
 
 public class RateLimiterTest {
   RateLimiter limiter;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/Constants.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/Constants.java
@@ -19,10 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock;
 
 public class Constants {
-  public final static String BAGGAGE_KEY = "crossdock-baggage-key";
-  public final static String TRANSPORT_HTTP = "HTTP";
-  public final static String TRANSPORT_TCHANNEL = "TCHANNEL";
+  public static final String BAGGAGE_KEY = "crossdock-baggage-key";
+  public static final String TRANSPORT_HTTP = "HTTP";
+  public static final String TRANSPORT_TCHANNEL = "TCHANNEL";
 }

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -19,20 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock;
-
-import java.net.URI;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-
-import org.apache.log4j.BasicConfigurator;
-import org.glassfish.grizzly.http.server.HttpServer;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.filter.LoggingFilter;
-import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
-import org.glassfish.jersey.jackson.JacksonFeature;
-import org.glassfish.jersey.server.ResourceConfig;
 
 import com.uber.jaeger.Configuration;
 import com.uber.jaeger.Configuration.ReporterConfiguration;
@@ -46,8 +34,17 @@ import com.uber.jaeger.crossdock.resources.behavior.tchannel.TChannelServer;
 import com.uber.jaeger.crossdock.resources.health.HealthResource;
 import com.uber.jaeger.filters.jaxrs2.TracingUtils;
 import com.uber.jaeger.samplers.ConstSampler;
-
 import io.opentracing.Tracer;
+import java.net.URI;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import org.apache.log4j.BasicConfigurator;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
 
 public class JerseyServer {
   public static final String SERVICE_NAME = "java";
@@ -91,8 +88,8 @@ public class JerseyServer {
 
     // create and start a new instance of grizzly http server
     // exposing the Jersey application at BASE_URI
-    String baseURI = String.format("http://%s/", hostPort);
-    server = GrizzlyHttpServerFactory.createHttpServer(URI.create(baseURI), rc);
+    String baseUri = String.format("http://%s/", hostPort);
+    server = GrizzlyHttpServerFactory.createHttpServer(URI.create(baseUri), rc);
     client = initializeClient(config);
   }
 

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/CreateTracesRequest.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/CreateTracesRequest.java
@@ -19,15 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.uber.jaeger.samplers.RemoteControlledSampler;
+import java.util.Map;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 @ToString
 @Getter

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/Downstream.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/Downstream.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/JoinTraceRequest.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/JoinTraceRequest.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/ObservedSpan.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/ObservedSpan.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/StartTraceRequest.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/StartTraceRequest.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/TraceResponse.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/api/TraceResponse.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/EndToEndBehavior.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/EndToEndBehavior.java
@@ -19,10 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.crossdock.resources.behavior;
 
-import java.util.HashMap;
-import java.util.Map;
+package com.uber.jaeger.crossdock.resources.behavior;
 
 import com.uber.jaeger.crossdock.api.CreateTracesRequest;
 import com.uber.jaeger.metrics.Metrics;
@@ -32,14 +30,15 @@ import com.uber.jaeger.metrics.StatsFactoryImpl;
 import com.uber.jaeger.reporters.RemoteReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.ConstSampler;
-import com.uber.jaeger.samplers.HTTPSamplingManager;
+import com.uber.jaeger.samplers.HttpSamplingManager;
 import com.uber.jaeger.samplers.ProbabilisticSampler;
 import com.uber.jaeger.samplers.RemoteControlledSampler;
 import com.uber.jaeger.samplers.Sampler;
-import com.uber.jaeger.senders.UDPSender;
-
+import com.uber.jaeger.senders.UdpSender;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EndToEndBehavior {
   private static final String SERVICE_NAME = "crossdock-java";
@@ -61,17 +60,19 @@ public class EndToEndBehavior {
   }
 
   private Reporter getReporter(Metrics metrics) {
-    UDPSender sender = new UDPSender(host, 5775, 0);
+    UdpSender sender = new UdpSender(host, 5775, 0);
     return new RemoteReporter(sender, 1000, 100, metrics);
   }
 
   private Tracer getRemoteTracer(Metrics metrics, Reporter reporter) {
     Sampler initialSampler = new ProbabilisticSampler(1.0);
-    HTTPSamplingManager manager = new HTTPSamplingManager(host + ":5778");
+    HttpSamplingManager manager = new HttpSamplingManager(host + ":5778");
 
-    RemoteControlledSampler remoteSampler = new RemoteControlledSampler(SERVICE_NAME, manager, initialSampler, metrics, 5000);
+    RemoteControlledSampler remoteSampler = new RemoteControlledSampler(SERVICE_NAME, manager, initialSampler,
+        metrics, 5000);
 
-    com.uber.jaeger.Tracer.Builder remoteTracerBuilder = new com.uber.jaeger.Tracer.Builder(SERVICE_NAME, reporter, remoteSampler);
+    com.uber.jaeger.Tracer.Builder remoteTracerBuilder = new com.uber.jaeger.Tracer.Builder(SERVICE_NAME, reporter,
+        remoteSampler);
     return remoteTracerBuilder.build();
   }
 
@@ -80,7 +81,7 @@ public class EndToEndBehavior {
     this.tracers = tracers;
   }
 
-  public void GenerateTraces(CreateTracesRequest request) {
+  public void generateTraces(CreateTracesRequest request) {
     String samplerType = request.getType();
     Tracer tracer = tracers.get(samplerType);
     for (int i = 0; i < request.getCount(); i++) {

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/ExceptionMapper.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/ExceptionMapper.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior;
 
 import javax.ws.rs.core.Response;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/TraceBehavior.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/TraceBehavior.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,7 +38,6 @@ import com.uber.tchannel.api.SubChannel;
 import com.uber.tchannel.api.TFuture;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -71,7 +71,7 @@ public class TraceBehavior {
     String transport = downstream.getTransport();
     switch (transport) {
       case Constants.TRANSPORT_HTTP:
-        return callDownstreamHTTP(downstream);
+        return callDownstreamHttp(downstream);
       case Constants.TRANSPORT_TCHANNEL:
         return callDownstreamTChannel(downstream);
       default:
@@ -79,14 +79,14 @@ public class TraceBehavior {
     }
   }
 
-  private TraceResponse callDownstreamHTTP(Downstream downstream) throws IOException {
-    String downstreamURL =
+  private TraceResponse callDownstreamHttp(Downstream downstream) throws IOException {
+    String downstreamUrl =
         String.format("http://%s:%s/join_trace", downstream.getHost(), downstream.getPort());
-    log.info("Calling downstream http {} at {}", downstream.getServiceName(), downstreamURL);
+    log.info("Calling downstream http {} at {}", downstream.getServiceName(), downstreamUrl);
 
     Response resp =
         JerseyServer.client
-            .target(downstreamURL)
+            .target(downstreamUrl)
             .request(MediaType.APPLICATION_JSON)
             .post(
                 Entity.json(
@@ -138,10 +138,10 @@ public class TraceBehavior {
     }
 
     SpanContext context = span.context();
-    String traceID = String.format("%x", context.getTraceID());
+    String traceId = String.format("%x", context.getTraceId());
     boolean sampled = context.isSampled();
     String baggage = span.getBaggageItem(Constants.BAGGAGE_KEY);
-    return new ObservedSpan(traceID, sampled, baggage);
+    return new ObservedSpan(traceId, sampled, baggage);
   }
 
   private InetAddress host(Downstream downstream) {

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/http/EndToEndBehaviorResource.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/http/EndToEndBehaviorResource.java
@@ -19,13 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uber.jaeger.crossdock.api.CreateTracesRequest;
 import com.uber.jaeger.crossdock.resources.behavior.EndToEndBehavior;
 import io.opentracing.Tracer;
-
+import java.util.Map;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -34,8 +35,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Map;
 
 /**
  * Handles creating traces from a http request.
@@ -79,7 +78,7 @@ public class EndToEndBehaviorResource {
   @Produces(MediaType.APPLICATION_JSON)
   public Response createTraces(CreateTracesRequest request) throws Exception {
     log.info("http:create_traces request: {}", mapper.writeValueAsString(request));
-    behavior.GenerateTraces(request);
+    behavior.generateTraces(request);
     return Response.ok("OK").build();
   }
 }

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResource.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResource.java
@@ -19,18 +19,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.crossdock.Constants;
-import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
 import com.uber.jaeger.crossdock.api.JoinTraceRequest;
 import com.uber.jaeger.crossdock.api.StartTraceRequest;
 import com.uber.jaeger.crossdock.api.TraceResponse;
+import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
 import io.opentracing.tag.Tags;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/JoinTraceThriftHandler.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/JoinTraceThriftHandler.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior.tchannel;
 
 import com.uber.jaeger.crossdock.api.Downstream;
@@ -29,7 +30,6 @@ import com.uber.jaeger.crossdock.thrift.TracedService;
 import com.uber.tchannel.api.handlers.ThriftRequestHandler;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/TChannelServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/TChannelServer.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.behavior.tchannel;
 
 import com.uber.jaeger.context.TracingUtils;
@@ -28,7 +29,6 @@ import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.tracing.TracingContext;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-
 import java.net.InetAddress;
 import java.util.EmptyStackException;
 

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/health/HealthResource.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/health/HealthResource.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.crossdock.resources.health;
 
 import javax.ws.rs.HEAD;

--- a/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/EndToEndBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/EndToEndBehaviorResourceTest.java
@@ -21,17 +21,20 @@
  */
 package com.uber.jaeger.crossdock.resources.behavior.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.uber.jaeger.Span;
-import com.uber.jaeger.crossdock.api.*;
+import com.uber.jaeger.crossdock.api.CreateTracesRequest;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.Tracer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 public class EndToEndBehaviorResourceTest {
   private EndToEndBehaviorResource resource;

--- a/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
@@ -21,18 +21,28 @@
  */
 package com.uber.jaeger.crossdock.resources.behavior.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.uber.jaeger.Span;
 import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.crossdock.Constants;
 import com.uber.jaeger.crossdock.JerseyServer;
-import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
-import com.uber.jaeger.crossdock.resources.behavior.tchannel.TChannelServer;
 import com.uber.jaeger.crossdock.api.Downstream;
 import com.uber.jaeger.crossdock.api.JoinTraceRequest;
 import com.uber.jaeger.crossdock.api.ObservedSpan;
 import com.uber.jaeger.crossdock.api.StartTraceRequest;
 import com.uber.jaeger.crossdock.api.TraceResponse;
+import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
+import com.uber.jaeger.crossdock.resources.behavior.tchannel.TChannelServer;
 import io.opentracing.tag.Tags;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.log4j.BasicConfigurator;
 import org.junit.After;
 import org.junit.Before;
@@ -40,17 +50,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class TraceBehaviorResourceTest {
@@ -101,7 +100,7 @@ public class TraceBehaviorResourceTest {
     Span span = (Span) server.getTracer().buildSpan("root").start();
     TracingUtils.getTraceContext().push(span);
 
-    String expectedTraceId = String.format("%x", span.context().getTraceID());
+    String expectedTraceId = String.format("%x", span.context().getTraceId());
     String expectedBaggage = "baggage-example";
 
     Downstream downstream =
@@ -126,7 +125,7 @@ public class TraceBehaviorResourceTest {
     Span span = (Span) server.getTracer().buildSpan("root").start();
     TracingUtils.getTraceContext().push(span);
 
-    String expectedTraceId = String.format("%x", span.context().getTraceID());
+    String expectedTraceId = String.format("%x", span.context().getTraceId());
     String expectedBaggage = "baggage-example";
     span.setBaggageItem(Constants.BAGGAGE_KEY, expectedBaggage);
     if (expectedSampled) {
@@ -161,7 +160,7 @@ public class TraceBehaviorResourceTest {
     Span span = (Span) server.getTracer().buildSpan("root").start();
     TracingUtils.getTraceContext().push(span);
 
-    String expectedTraceId = String.format("%x", span.context().getTraceID());
+    String expectedTraceId = String.format("%x", span.context().getTraceId());
     String expectedBaggage = "baggage-example";
     span.setBaggageItem(Constants.BAGGAGE_KEY, expectedBaggage);
     if (expectedSampled) {

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/Configuration.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/Configuration.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;
@@ -46,7 +47,7 @@ public class Configuration extends com.uber.jaeger.Configuration {
   }
 
   @Override
-  synchronized public Tracer getTracer() {
+  public synchronized Tracer getTracer() {
     if (disable) {
       return NoopTracerFactory.create();
     }

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/CounterImpl.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/CounterImpl.java
@@ -19,12 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.uber.jaeger.metrics.Counter;
-
 import java.util.Map;
 
 public class CounterImpl implements Counter {

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/GaugeImpl.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/GaugeImpl.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JaegerFeature.java
@@ -19,12 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.uber.jaeger.filters.jaxrs2.TracingUtils;
-
 import io.opentracing.Tracer;
-
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
@@ -47,6 +46,7 @@ public class JaegerFeature implements Feature {
             new JerseyServerFilter(tracer, com.uber.jaeger.context.TracingUtils.getTraceContext()));
         break;
       case CLIENT:
+      default:
         featureContext.register(TracingUtils.clientFilter(tracer));
         break;
     }

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/JerseyServerFilter.java
@@ -19,32 +19,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ServerFilter;
-
-import org.glassfish.jersey.server.ContainerRequest;
-import org.glassfish.jersey.server.ExtendedUriInfo;
-import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
-import org.glassfish.jersey.uri.UriTemplate;
-
+import io.opentracing.Tracer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.ext.Provider;
-
-import io.opentracing.Tracer;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
+import org.glassfish.jersey.uri.UriTemplate;
 
 /**
  * A {@link ServerFilter} that provides a Jersey specific {@link #getOperationName} implementation.

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/ReporterConfiguration.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/ReporterConfiguration.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/SamplerConfiguration.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/SamplerConfiguration.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/StatsFactory.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/StatsFactory.java
@@ -19,13 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;
 import com.uber.jaeger.metrics.Counter;
 import com.uber.jaeger.metrics.Gauge;
 import com.uber.jaeger.metrics.Timer;
-
 import java.util.Map;
 
 public class StatsFactory implements com.uber.jaeger.metrics.StatsFactory {

--- a/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/TimerImpl.java
+++ b/jaeger-dropwizard/src/main/java/com/uber/jaeger/dropwizard/TimerImpl.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.dropwizard;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -27,10 +27,6 @@ import static junit.framework.Assert.assertTrue;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Test;
-
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
@@ -40,6 +36,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
 
 public class JerseyServerFilterTest extends JerseyTest {
 

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/StatsFactoryTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/StatsFactoryTest.java
@@ -21,22 +21,21 @@
  */
 package com.uber.jaeger.dropwizard;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
 
 public class StatsFactoryTest {
   MetricRegistry registry;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import com.uber.jaeger.context.TraceContext;
@@ -26,7 +27,6 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
-
 import java.io.IOException;
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientRequestCarrier.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientRequestCarrier.java
@@ -19,15 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import io.opentracing.propagation.TextMap;
-
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.core.MultivaluedMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
+import javax.ws.rs.client.ClientRequestContext;
 
 public class ClientRequestCarrier implements TextMap {
   private final ClientRequestContext requestContext;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 public class Constants {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import com.uber.jaeger.context.TraceContext;
@@ -27,7 +28,6 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
-
 import java.io.IOException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerRequestCarrier.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerRequestCarrier.java
@@ -19,15 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import io.opentracing.propagation.TextMap;
-
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MultivaluedMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
 
 public class ServerRequestCarrier implements TextMap {
   private final ContainerRequestContext requestContext;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -19,11 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import com.uber.jaeger.context.TraceContext;
 import io.opentracing.Tracer;
-
 import java.util.concurrent.ExecutorService;
 
 public class TracingUtils {

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -32,6 +32,12 @@ import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,13 +45,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientResponseContext;
-import javax.ws.rs.core.MultivaluedHashMap;
 
 /**
  * Tests that {@link ClientFilter} produces a span and sets tags correctly See also:

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
@@ -25,21 +25,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.UriInfo;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.Tracer;
@@ -48,8 +33,19 @@ import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.propagation.FilterIntegrationTest;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
-
 import io.opentracing.tag.Tags;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.UriInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * Tests that {@link ServerFilter} produces a span and sets tags correctly See also:

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/CallTreeNode.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/CallTreeNode.java
@@ -23,10 +23,9 @@ package com.uber.jaeger.propagation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import javax.ws.rs.ext.Provider;
 import java.util.ArrayList;
 import java.util.List;
+import javax.ws.rs.ext.Provider;
 
 /*
  * This class is used for presenting individual spans, and capturing the recursive

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
@@ -21,6 +21,12 @@
  */
 package com.uber.jaeger.propagation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.context.ThreadLocalTraceContext;
@@ -33,11 +39,6 @@ import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
-import org.glassfish.jersey.jackson.JacksonFeature;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -45,12 +46,10 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class FilterIntegrationTest {
   private JerseyServer server;

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyHandler.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyHandler.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ClientFilter;
 import io.opentracing.Tracer;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.jackson.JacksonFeature;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -40,9 +40,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.jackson.JacksonFeature;
 
 @Path("jersey")
 public class JerseyHandler {

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyServer.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyServer.java
@@ -24,14 +24,13 @@ package com.uber.jaeger.propagation;
 import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ServerFilter;
 import io.opentracing.Tracer;
+import java.io.IOException;
+import java.net.URI;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-
-import java.io.IOException;
-import java.net.URI;
 
 public class JerseyServer {
   // Base URI the Grizzly HTTP server will listen on

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/SpanInfo.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/SpanInfo.java
@@ -48,7 +48,7 @@ class SpanInfo {
 
   public SpanInfo(Span span) {
     SpanContext spanContext = span.context();
-    traceID = Long.toHexString(spanContext.getTraceID());
+    traceID = Long.toHexString(spanContext.getTraceId());
     baggage = span.getBaggageItem(FilterIntegrationTest.BAGGAGE_KEY);
     sampled = spanContext.isSampled();
   }

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -32,8 +32,6 @@ javadoc {
     exclude '**/com/uber/jaeger/crossdock/thrift/**'
 }
 
-licenseMain.enabled = false
-
 sourceSets {
     main {
         java {
@@ -52,6 +50,10 @@ jar {
         attributes('Implementation-Title': 'jaeger-thrift', 'Implementation-Version': project.version)
     }
 }
+
+licenseMain.enabled = false
+checkstyleMain.enabled = false
+checkstyleTest.enabled = false
 
 shadowJar {
     baseName = 'jaeger-thrift'

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverter.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverter.java
@@ -19,12 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.senders.zipkin;
 
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+package com.uber.jaeger.senders.zipkin;
 
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.AnnotationType;
@@ -36,8 +32,11 @@ import com.uber.jaeger.LogData;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.SpanContext;
 import com.uber.jaeger.Tracer;
-
 import io.opentracing.tag.Tags;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class ThriftSpanConverter {
 
@@ -45,16 +44,16 @@ public class ThriftSpanConverter {
 
   public static com.twitter.zipkin.thriftjava.Span convertSpan(Span span) {
     Tracer tracer = span.getTracer();
-    Endpoint host = new Endpoint(tracer.getIP(), (short) 0, tracer.getServiceName());
+    Endpoint host = new Endpoint(tracer.getIp(), (short) 0, tracer.getServiceName());
 
-  SpanContext context = span.context();
+    SpanContext context = span.context();
     return new com.twitter.zipkin.thriftjava.Span(
-            context.getTraceID(),
+            context.getTraceId(),
             span.getOperationName(),
-            context.getSpanID(),
+            context.getSpanId(),
             buildAnnotations(span, host),
             buildBinaryAnnotations(span, host))
-        .setParent_id(context.getParentID())
+        .setParent_id(context.getParentId())
         .setDebug(context.isDebug())
         .setTimestamp(span.getStart())
         .setDuration(span.getDuration());
@@ -63,10 +62,10 @@ public class ThriftSpanConverter {
   private static List<Annotation> buildAnnotations(Span span, Endpoint host) {
     List<Annotation> annotations = new ArrayList<Annotation>();
 
-    if (isRPC(span)) {
+    if (isRpc(span)) {
       String startLabel = zipkincoreConstants.SERVER_RECV;
       String endLabel = zipkincoreConstants.SERVER_SEND;
-      if (isRPCClient(span)) {
+      if (isRpcClient(span)) {
         startLabel = zipkincoreConstants.CLIENT_SEND;
         endLabel = zipkincoreConstants.CLIENT_RECV;
       }
@@ -88,8 +87,8 @@ public class ThriftSpanConverter {
   private static List<BinaryAnnotation> buildBinaryAnnotations(Span span, Endpoint host) {
     List<BinaryAnnotation> binaryAnnotations = new ArrayList<BinaryAnnotation>();
     Map<String, Object> tags = span.getTags();
-    boolean isRpc = isRPC(span);
-    boolean isClient = isRPCClient(span);
+    boolean isRpc = isRpc(span);
+    boolean isClient = isRpcClient(span);
 
     Endpoint peerEndpoint = extractPeerEndpoint(tags);
     if (peerEndpoint != null && isClient) {
@@ -146,13 +145,13 @@ public class ThriftSpanConverter {
     return banno;
   }
 
-  public static boolean isRPC(Span span) {
+  public static boolean isRpc(Span span) {
     Object spanKindValue = span.getTags().get(Tags.SPAN_KIND.getKey());
     return Tags.SPAN_KIND_CLIENT.equals(spanKindValue) || Tags.SPAN_KIND_SERVER.equals(spanKindValue);
 
   }
 
-  public static boolean isRPCClient(Span span) {
+  public static boolean isRpcClient(Span span) {
     return Tags.SPAN_KIND_CLIENT.equals(span.getTags().get(Tags.SPAN_KIND.getKey()));
   }
 

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanEncoder.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanEncoder.java
@@ -19,14 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.uber.jaeger.senders.zipkin;
 
 import com.twitter.zipkin.thriftjava.Span;
+import java.io.ByteArrayOutputStream;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
-
-import java.io.ByteArrayOutputStream;
 import zipkin.reporter.Encoder;
 import zipkin.reporter.Encoding;
 

--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ZipkinSender.java
@@ -19,12 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.uber.jaeger.senders.zipkin;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+package com.uber.jaeger.senders.zipkin;
 
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.BinaryAnnotation;
@@ -33,7 +29,10 @@ import com.twitter.zipkin.thriftjava.Span;
 import com.twitter.zipkin.thriftjava.zipkincoreConstants;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.senders.Sender;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.ToString;
 import zipkin.Constants;
 import zipkin.reporter.Encoding;

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
@@ -21,18 +21,9 @@
  */
 package com.uber.jaeger.senders.zipkin;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
-import static junit.framework.TestCase.assertTrue;
-
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.zipkincoreConstants;
@@ -41,12 +32,17 @@ import com.uber.jaeger.SpanContext;
 import com.uber.jaeger.Tracer;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
-
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import io.opentracing.propagation.TextMapInjectAdapter;
 import io.opentracing.tag.Tags;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ThriftSpanConverterTest {
   Tracer tracer;
@@ -55,7 +51,7 @@ public class ThriftSpanConverterTest {
   public void setUp() {
     tracer =
         new Tracer.Builder("test-service-name", new InMemoryReporter(), new ConstSampler(true))
-                .withZipkinSharedRPCSpan()
+                .withZipkinSharedRpcSpan()
             .build();
   }
 
@@ -139,8 +135,8 @@ public class ThriftSpanConverterTest {
     Span span = (Span) tracer.buildSpan("test-service-operation").start();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
 
-    assertTrue(ThriftSpanConverter.isRPC(span));
-    assertTrue(ThriftSpanConverter.isRPCClient(span));
+    assertTrue(ThriftSpanConverter.isRpc(span));
+    assertTrue(ThriftSpanConverter.isRpcClient(span));
   }
 
   @Test
@@ -148,8 +144,8 @@ public class ThriftSpanConverterTest {
     Span span = (Span) tracer.buildSpan("test-service-operation").start();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
 
-    assertTrue(ThriftSpanConverter.isRPC(span));
-    assertFalse(ThriftSpanConverter.isRPCClient(span));
+    assertTrue(ThriftSpanConverter.isRpc(span));
+    assertFalse(ThriftSpanConverter.isRpcClient(span));
   }
 
    @Test
@@ -165,7 +161,7 @@ public class ThriftSpanConverterTest {
 
      carrier = new TextMapExtractAdapter(map);
      SpanContext ctx = (SpanContext) tracer.extract(Format.Builtin.TEXT_MAP, carrier);
-     assertEquals(client.context().getSpanID(), ctx.getSpanID());
+     assertEquals(client.context().getSpanId(), ctx.getSpanId());
 
      Span server = (Span)tracer.buildSpan("child")
              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
@@ -173,6 +169,6 @@ public class ThriftSpanConverterTest {
              .start();
 
      assertEquals("client and server must have the same span ID",
-             client.context().getSpanID(), server.context().getSpanID());
+             client.context().getSpanId(), server.context().getSpanId());
    }
 }

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
@@ -23,15 +23,6 @@ package com.uber.jaeger.senders.zipkin;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import com.uber.jaeger.Span;
 import com.uber.jaeger.SpanContext;
 import com.uber.jaeger.Tracer;
@@ -40,7 +31,13 @@ import com.uber.jaeger.metrics.InMemoryStatsReporter;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.ConstSampler;
-
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import zipkin.Annotation;
 import zipkin.BinaryAnnotation;
 import zipkin.junit.ZipkinRule;
@@ -132,9 +129,9 @@ public class ZipkinSenderTest {
     zipkin.Span actualSpan = traces.get(0).get(0);
     SpanContext context = expectedSpan.context();
 
-    assertEquals(context.getTraceID(), actualSpan.traceId);
-    assertEquals(context.getSpanID(), actualSpan.id);
-    assertEquals(context.getParentID(), (long) actualSpan.parentId);
+    assertEquals(context.getTraceId(), actualSpan.traceId);
+    assertEquals(context.getSpanId(), actualSpan.id);
+    assertEquals(context.getParentId(), (long) actualSpan.parentId);
     assertEquals(expectedSpan.getOperationName(), actualSpan.name);
     for (BinaryAnnotation binaryAnnotation : actualSpan.binaryAnnotations) {
       assertEquals(tracer.getServiceName(), binaryAnnotation.endpoint.serviceName);


### PR DESCRIPTION
Related to #148, resolves #147 

Use only standard gradle checkstyle plugin with google checkstyle definitions from https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml. If we feel that some of the rules are too strict we can adjust/disable annoying ones. 

Note that auto formatting provided by `com.github.sherter.google-java-format` does not work very well it does not format code properly. 

This fails `./gradle test`. If we agree I will apply style changes to align current code base with google code style (there are tons of violation right now, imports, javadoc, no empty lines, naming conventions). 
