### PR TITLE
Add license test to gradle checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ subprojects {
         }
     }
 
-    classes.dependsOn tasks.licenseFormat
+    check.dependsOn tasks.license
     classes.dependsOn tasks.verifyFormatting
 
     apply from: '../gradle/publish.gradle'


### PR DESCRIPTION
Gates builds on license violations instead of applying licenses during a build (and allowing non licensed code to be checked in).