### PR TITLE
Multiple references clarification

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -57,7 +57,7 @@ public class Span implements io.opentracing.Span {
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
     this.tags = new HashMap<String, Object>();
-    this.references = new ArrayList<Reference>(references);
+    this.references = references != null ? new ArrayList<Reference>(references) : null;
 
     for (Map.Entry<String, Object> tag : tags.entrySet()) {
       setTagAsObject(tag.getKey(), tag.getValue());
@@ -79,9 +79,10 @@ public class Span implements io.opentracing.Span {
   }
 
   public List<Reference> getReferences() {
-    synchronized (this) {
-      return Collections.unmodifiableList(references);
+    if (references == null) {
+      return Collections.emptyList();
     }
+    return Collections.unmodifiableList(references);
   }
 
   public Map<String, Object> getTags() {


### PR DESCRIPTION
This should clarify how multiple references should be processed. Previous discussion: https://github.com/uber/jaeger-client-java/pull/142#discussion_r113798215

Jaeger thrift span model holds a list of references but also `long parenId`. This `parentId` should be used for `childOf` reference to save payload as in 99% of situations there is only one childOf reference. However, this adds a little bit of confusion to the model. 

E.g:
* there is one 'childOf' refs. `parentId` is used.
* there are multiple `childOf` refs. Which one should be used as `parentId`? Should be one treated in a spacial way as a preferred parent?

I propose that `parentId` should be used only for situations when there is only one `childOf` reference. in all other situations pass all references in the list of references to keep it semantically clear.

I would like to also clarify sampling, debug and traceId when there are multiple references (potentially from diffrent traces).