### PR TITLE
Normalize Configuration.fromEnv() methods

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -116,6 +116,10 @@ public class Configuration {
    */
   private Tracer tracer;
 
+  public Configuration(String serviceName) {
+    this(serviceName, null, null);
+  }
+
   public Configuration(
       String serviceName,
       SamplerConfiguration samplerConfig,
@@ -140,24 +144,10 @@ public class Configuration {
   }
 
   public static Configuration fromEnv() {
-    return new Configuration(getProperty(JAEGER_SERVICE_NAME),
-        getSamplerConfigurationFromEnv(), getReporterConfigurationFromEnv());
-  }
-
-  static ReporterConfiguration getReporterConfigurationFromEnv() {
-    return new ReporterConfiguration(
-        getPropertyAsBoolean(JAEGER_REPORTER_LOG_SPANS),
-        getProperty(JAEGER_AGENT_HOST),
-        getPropertyAsInt(JAEGER_AGENT_PORT),
-        getPropertyAsInt(JAEGER_REPORTER_FLUSH_INTERVAL),
-        getPropertyAsInt(JAEGER_REPORTER_MAX_QUEUE_SIZE));
-  }
-
-  static SamplerConfiguration getSamplerConfigurationFromEnv() {
-    return new SamplerConfiguration(
-        getProperty(JAEGER_SAMPLER_TYPE),
-        getPropertyAsNum(JAEGER_SAMPLER_PARAM),
-        getProperty(JAEGER_SAMPLER_MANAGER_HOST_PORT));
+    return new Configuration(
+        getProperty(JAEGER_SERVICE_NAME),
+        SamplerConfiguration.fromEnv(),
+        ReporterConfiguration.fromEnv());
   }
 
   public Tracer.Builder getTracerBuilder() {
@@ -233,6 +223,14 @@ public class Configuration {
       this.managerHostPort = managerHostPort;
     }
 
+    public static SamplerConfiguration fromEnv() {
+      return new SamplerConfiguration(
+          getProperty(JAEGER_SAMPLER_TYPE),
+          getPropertyAsNum(JAEGER_SAMPLER_PARAM),
+          getProperty(JAEGER_SAMPLER_MANAGER_HOST_PORT));
+    }
+
+
     private Sampler createSampler(String serviceName, Metrics metrics) {
       String samplerType = stringOrDefault(this.getType(), RemoteControlledSampler.TYPE);
       Number samplerParam = numberOrDefault(this.getParam(), DEFAULT_SAMPLING_PROBABILITY);
@@ -306,6 +304,15 @@ public class Configuration {
       this.agentPort = agentPort;
       this.flushIntervalMs = flushIntervalMs;
       this.maxQueueSize = maxQueueSize;
+    }
+
+    public static ReporterConfiguration fromEnv() {
+      return new ReporterConfiguration(
+          getPropertyAsBoolean(JAEGER_REPORTER_LOG_SPANS),
+          getProperty(JAEGER_AGENT_HOST),
+          getPropertyAsInt(JAEGER_AGENT_PORT),
+          getPropertyAsInt(JAEGER_REPORTER_FLUSH_INTERVAL),
+          getPropertyAsInt(JAEGER_REPORTER_MAX_QUEUE_SIZE));
     }
 
     private Reporter getReporter(Metrics metrics) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -63,7 +63,7 @@ public class ConfigurationTest {
   public void testSamplerConst() {
     System.setProperty(Configuration.JAEGER_SAMPLER_TYPE, ConstSampler.TYPE);
     System.setProperty(Configuration.JAEGER_SAMPLER_PARAM, "1");
-    SamplerConfiguration samplerConfig = Configuration.getSamplerConfigurationFromEnv();
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
     assertEquals(ConstSampler.TYPE, samplerConfig.getType());
     assertEquals(1, samplerConfig.getParam().intValue());
   }
@@ -72,7 +72,7 @@ public class ConfigurationTest {
   public void testSamplerConstInvalidParam() {
     System.setProperty(Configuration.JAEGER_SAMPLER_TYPE, ConstSampler.TYPE);
     System.setProperty(Configuration.JAEGER_SAMPLER_PARAM, "X");
-    SamplerConfiguration samplerConfig = Configuration.getSamplerConfigurationFromEnv();
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
     assertEquals(ConstSampler.TYPE, samplerConfig.getType());
     assertNull(samplerConfig.getParam());
   }
@@ -84,7 +84,7 @@ public class ConfigurationTest {
     System.setProperty(Configuration.JAEGER_AGENT_PORT, "1234");
     System.setProperty(Configuration.JAEGER_REPORTER_FLUSH_INTERVAL, "500");
     System.setProperty(Configuration.JAEGER_REPORTER_MAX_QUEUE_SIZE, "1000");
-    ReporterConfiguration reporterConfig = Configuration.getReporterConfigurationFromEnv();
+    ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
     assertTrue(reporterConfig.getLogSpans());
     assertEquals("MyHost", reporterConfig.getAgentHost());
     assertEquals(1234, reporterConfig.getAgentPort().intValue());
@@ -95,14 +95,14 @@ public class ConfigurationTest {
   @Test
   public void testReporterConfigurationInvalidFlushInterval() {
     System.setProperty(Configuration.JAEGER_REPORTER_FLUSH_INTERVAL, "X");
-    ReporterConfiguration reporterConfig = Configuration.getReporterConfigurationFromEnv();
+    ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
     assertNull(reporterConfig.getFlushIntervalMs());
   }
 
   @Test
   public void testReporterConfigurationInvalidLogSpans() {
     System.setProperty(Configuration.JAEGER_REPORTER_LOG_SPANS, "X");
-    ReporterConfiguration reporterConfig = Configuration.getReporterConfigurationFromEnv();
+    ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
     assertFalse(reporterConfig.getLogSpans());
   }
 


### PR DESCRIPTION
Give each configuration class a static `fromEnv()` factory method