### PR TITLE
Fix Flaky RemoteReporter test

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/reporters/RemoteReporter.java
@@ -73,7 +73,7 @@ public class RemoteReporter implements Reporter {
             flush();
           }
         },
-        0,
+        flushInterval,
         flushInterval);
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -214,7 +214,10 @@ public class RemoteReporterTest {
     // change sender to blocking mode
     sender.permitAppend(0);
     RemoteReporter remoteReporter = (RemoteReporter) reporter;
-    remoteReporter.flush();
+
+    await("flush() execution via TimerTask").atMost(5, TimeUnit.SECONDS).until(
+        () -> metricsReporter.gauges.get("jaeger.reporter-queue") != null
+    );
 
     for (int i = 0; i < 10; i++) {
       reporter.report(newSpan());

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -213,7 +213,6 @@ public class RemoteReporterTest {
   public void testFlushUpdatesQueueLength() throws Exception {
     // change sender to blocking mode
     sender.permitAppend(0);
-    RemoteReporter remoteReporter = (RemoteReporter) reporter;
 
     await("flush() execution via TimerTask").atMost(5, TimeUnit.SECONDS).until(
         () -> metricsReporter.gauges.get("jaeger.reporter-queue") != null
@@ -225,6 +224,7 @@ public class RemoteReporterTest {
 
     assertEquals(0, metricsReporter.gauges.get("jaeger.reporter-queue").longValue());
 
+    RemoteReporter remoteReporter = (RemoteReporter) reporter;
     remoteReporter.flush();
 
     assertTrue(metricsReporter.gauges.get("jaeger.reporter-queue") > 5);


### PR DESCRIPTION
Explicitly waiting for TimerTask to call flush() - it never failed for me, but I think that this is the reason why it failed on CI

Fixes #184