### PR TITLE
Refactor RemoteReporter to speed up tests

### DIFF
--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -181,6 +181,11 @@ public class RemoteReporterTest {
 
   @Test
   public void testCloseWhenQueueFull() {
+    int closeTimeoutMillis = 5;
+    reporter = new RemoteReporter(sender, Integer.MAX_VALUE, maxQueueSize, closeTimeoutMillis, metrics);
+    tracer = new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
+        .withStatsReporter(metricsReporter)
+        .build();
     // change sender to blocking mode
     sender.permitAppend(0);
 


### PR DESCRIPTION
`RemoteReporterTest.testCloseWhenQueueFull()` takes 1 second to run because that's the timeout value - `CLOSE_ENQUEUE_TIMEOUT_MILLIS`. I've added package-protected constructor which allows to override this timeout in tests and make them fast.