### PR TITLE
Upgrade to OpenTracing java 0.30.0 with in-process propagation support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'ru.vyarus.animalsniffer' version '1.2.0'
 }
 
-ext.opentracingVersion = '0.22.0'
+ext.opentracingVersion = '0.30.0'
 ext.guavaVersion = '18.0'
 ext.apacheThriftVersion = '0.9.2'
 ext.jerseyVersion = '2.22.2'

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
@@ -66,7 +66,7 @@ public class TracingRequestInterceptor implements HttpRequestInterceptor {
         clientSpanBuilder.asChildOf(parentContext.getCurrentSpan());
       }
 
-      Span clientSpan = clientSpanBuilder.start();
+      Span clientSpan = clientSpanBuilder.startManual();
       Tags.SPAN_KIND.set(clientSpan, Tags.SPAN_KIND_CLIENT);
       Tags.HTTP_URL.set(clientSpan, requestLine.getUri());
 

--- a/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
+++ b/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
@@ -73,7 +73,7 @@ public class JaegerRequestAndResponseInterceptorIntegrationTest {
     Sampler sampler = new ConstSampler(true);
     tracer = new Tracer.Builder("test_service", reporter, sampler).build();
 
-    parentSpan = (Span) tracer.buildSpan("parent_operation").start();
+    parentSpan = (Span) tracer.buildSpan("parent_operation").startManual();
     parentSpan.setBaggageItem(BAGGAGE_KEY, BAGGAGE_VALUE);
     parentSpan.finish();
     //Set up a parent span context

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -3,6 +3,7 @@ description = 'Core library for jaeger-client'
 dependencies {
     compile project(':jaeger-thrift')
     compile group: 'io.opentracing', name: 'opentracing-api', version: opentracingVersion
+    compile group: 'io.opentracing', name: 'opentracing-util', version: opentracingVersion
     compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -169,7 +169,6 @@ public class Span implements io.opentracing.Span {
     }
   }
 
-  @Override
   public void close() {
     finish();
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Span.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Span.java
@@ -169,10 +169,6 @@ public class Span implements io.opentracing.Span {
     }
   }
 
-  public void close() {
-    finish();
-  }
-
   @Override
   public synchronized Span setTag(String key, String value) {
     return setTagAsObject(key, value);

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -283,6 +283,11 @@ public class Tracer implements io.opentracing.Tracer {
         }
       }
 
+      // Check if active span should be established as CHILD_OF relationship
+      if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
+        asChildOf(activeSpanSource.activeSpan());
+      }
+
       return new SpanContext(id, id, 0, flags);
     }
 
@@ -375,11 +380,6 @@ public class Tracer implements io.opentracing.Tracer {
       String debugId = debugId();
       if (references.isEmpty()) {
         context = createNewContext(null);
-
-        // Check if active span should be established as CHILD_OF relationship
-        if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
-          asChildOf(activeSpanSource.activeSpan());
-        }
       } else if (debugId != null) {
         context = createNewContext(debugId);
       } else {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -265,6 +265,8 @@ public class Tracer implements io.opentracing.Tracer {
 
     private SpanContext createNewContext(String debugId) {
       long id = Utils.uniqueId();
+      long traceId = id;
+      long parentId = 0;
 
       byte flags = 0;
       if (debugId != null) {
@@ -285,10 +287,13 @@ public class Tracer implements io.opentracing.Tracer {
 
       // Check if active span should be established as CHILD_OF relationship
       if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
-        asChildOf(activeSpanSource.activeSpan());
+        SpanContext parentContext = (SpanContext) activeSpanSource.activeSpan().context();
+        asChildOf(parentContext);
+        traceId = parentContext.getTraceId();
+        parentId = parentContext.getSpanId();
       }
 
-      return new SpanContext(id, id, 0, flags);
+      return new SpanContext(traceId, id, parentId, flags);
     }
 
     private Map<String, String> createChildBaggage() {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -373,7 +373,7 @@ public class Tracer implements io.opentracing.Tracer {
       SpanContext context;
 
       // Check if active span should be established as CHILD_OF relationship
-      if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
+      if (references.isEmpty() && !ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
         asChildOf(activeSpanSource.activeSpan());
       }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -265,8 +265,6 @@ public class Tracer implements io.opentracing.Tracer {
 
     private SpanContext createNewContext(String debugId) {
       long id = Utils.uniqueId();
-      long traceId = id;
-      long parentId = 0;
 
       byte flags = 0;
       if (debugId != null) {
@@ -285,15 +283,7 @@ public class Tracer implements io.opentracing.Tracer {
         }
       }
 
-      // Check if active span should be established as CHILD_OF relationship
-      if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
-        SpanContext parentContext = (SpanContext) activeSpanSource.activeSpan().context();
-        asChildOf(parentContext);
-        traceId = parentContext.getTraceId();
-        parentId = parentContext.getSpanId();
-      }
-
-      return new SpanContext(traceId, id, parentId, flags);
+      return new SpanContext(id, id, 0, flags);
     }
 
     private Map<String, String> createChildBaggage() {
@@ -381,6 +371,11 @@ public class Tracer implements io.opentracing.Tracer {
     @Override
     public io.opentracing.Span startManual() {
       SpanContext context;
+
+      // Check if active span should be established as CHILD_OF relationship
+      if (!ignoreActiveSpan && null != activeSpanSource.activeSpan()) {
+        asChildOf(activeSpanSource.activeSpan());
+      }
 
       String debugId = debugId();
       if (references.isEmpty()) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/PropagationTest.java
@@ -24,9 +24,14 @@ package com.uber.jaeger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.ActiveSpanSource;
+import io.opentracing.References;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.propagation.TextMapExtractAdapter;
@@ -45,10 +50,70 @@ public class PropagationTest {
     SpanContext spanContext = (SpanContext) tracer.extract(Format.Builtin.TEXT_MAP, carrier);
     assertTrue(spanContext.isDebugIdContainerOnly());
     assertEquals("Coraline", spanContext.getDebugId());
-    Span span = (Span) tracer.buildSpan("span").asChildOf(spanContext).start();
+    Span span = (Span) tracer.buildSpan("span").asChildOf(spanContext).startManual();
     spanContext = (SpanContext) span.context();
     assertTrue(spanContext.isSampled());
     assertTrue(spanContext.isDebug());
     assertEquals("Coraline", span.getTags().get(Constants.DEBUG_ID_HEADER_KEY));
+  }
+
+  @Test
+  public void testActiveSpanPropagation() {
+    Tracer tracer =
+        new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true)).build();
+    try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+      assertEquals(parent, tracer.activeSpan());
+    }
+  }
+
+  @Test
+  public void testActiveSpanAutoReference() {
+    InMemoryReporter reporter = new InMemoryReporter();
+    Tracer tracer =
+        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+      tracer.buildSpan("child").startActive().deactivate();
+    }
+    assertEquals(2, reporter.getSpans().size());
+    assertEquals("child", reporter.getSpans().get(0).getOperationName());
+    assertEquals(1, reporter.getSpans().get(0).getReferences().size());
+    assertEquals("parent", reporter.getSpans().get(1).getOperationName());
+    assertTrue(reporter.getSpans().get(1).getReferences().isEmpty());
+    assertEquals(References.CHILD_OF, reporter.getSpans().get(0).getReferences().get(0).getType());
+    assertEquals(reporter.getSpans().get(1).context(),
+        reporter.getSpans().get(0).getReferences().get(0).getSpanContext());
+  }
+
+  @Test
+  public void testIgnoreActiveSpan() {
+    InMemoryReporter reporter = new InMemoryReporter();
+    Tracer tracer =
+        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    try (ActiveSpan parent = tracer.buildSpan("parent").startActive()) {
+      tracer.buildSpan("child").ignoreActiveSpan().startActive().deactivate();
+    }
+    assertEquals(2, reporter.getSpans().size());
+    assertTrue(reporter.getSpans().get(0).getReferences().isEmpty());
+    assertTrue(reporter.getSpans().get(1).getReferences().isEmpty());
+  }
+
+  @Test
+  public void testCustomActiveSpanSource() {
+    ActiveSpan activeSpan = mock(ActiveSpan.class);
+    Tracer tracer =
+        new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true))
+        .withActiveSpanSource(new ActiveSpanSource() {
+
+          @Override
+          public ActiveSpan activeSpan() {
+            return activeSpan;
+          }
+
+          @Override
+          public ActiveSpan makeActive(io.opentracing.Span span) {
+            return activeSpan;
+          }
+        }).build();
+    assertEquals(activeSpan, tracer.activeSpan());
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/SpanTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/SpanTest.java
@@ -58,7 +58,7 @@ public class SpanTest {
             .withStatsReporter(metricsReporter)
             .withClock(clock)
             .build();
-    span = (Span) tracer.buildSpan("some-operation").start();
+    span = (Span) tracer.buildSpan("some-operation").startManual();
   }
 
   @Test
@@ -132,7 +132,7 @@ public class SpanTest {
     when(clock.currentNanoTicks())
         .thenThrow(new IllegalStateException("currentNanoTicks() called"));
 
-    Span span = (Span) tracer.buildSpan("test-service-name").withStartTimestamp(567).start();
+    Span span = (Span) tracer.buildSpan("test-service-name").withStartTimestamp(567).startManual();
     span.finish(999);
 
     assertEquals(1, reporter.getSpans().size());
@@ -147,7 +147,7 @@ public class SpanTest {
     when(clock.currentNanoTicks())
         .thenThrow(new IllegalStateException("currentNanoTicks() called"));
 
-    Span span = (Span) tracer.buildSpan("test-service-name").start();
+    Span span = (Span) tracer.buildSpan("test-service-name").startManual();
     span.finish();
 
     assertEquals(1, reporter.getSpans().size());
@@ -163,7 +163,7 @@ public class SpanTest {
         .thenThrow(new IllegalStateException("currentTimeMicros() called 2nd time"));
     when(clock.currentNanoTicks()).thenReturn(20000L).thenReturn(30000L);
 
-    Span span = (Span) tracer.buildSpan("test-service-name").start();
+    Span span = (Span) tracer.buildSpan("test-service-name").startManual();
     span.finish();
 
     assertEquals(1, reporter.getSpans().size());
@@ -173,7 +173,7 @@ public class SpanTest {
 
   @Test
   public void testSpanToString() {
-    Span span = (Span) tracer.buildSpan("test-operation").start();
+    Span span = (Span) tracer.buildSpan("test-operation").startManual();
     SpanContext expectedContext = span.context();
     SpanContext actualContext = SpanContext.contextFromString(span.context().contextAsString());
 
@@ -186,7 +186,7 @@ public class SpanTest {
   @Test
   public void testOperationName() {
     String expectedOperation = "leela";
-    Span span = (Span) tracer.buildSpan(expectedOperation).start();
+    Span span = (Span) tracer.buildSpan(expectedOperation).startManual();
     assertEquals(expectedOperation, span.getOperationName());
   }
 
@@ -271,7 +271,7 @@ public class SpanTest {
 
   @Test
   public void testSpanDetectsSamplingPriorityGreaterThanZero() {
-    Span span = (Span) tracer.buildSpan("test-service-operation").start();
+    Span span = (Span) tracer.buildSpan("test-service-operation").startManual();
     Tags.SAMPLING_PRIORITY.set(span, 1);
 
     assertEquals(span.context().getFlags() & SpanContext.flagSampled, SpanContext.flagSampled);
@@ -280,7 +280,7 @@ public class SpanTest {
 
   @Test
   public void testSpanDetectsSamplingPriorityLessThanZero() {
-    Span span = (Span) tracer.buildSpan("test-service-operation").start();
+    Span span = (Span) tracer.buildSpan("test-service-operation").startManual();
 
     assertEquals(span.context().getFlags() & SpanContext.flagSampled, SpanContext.flagSampled);
     Tags.SAMPLING_PRIORITY.set(span, -1);
@@ -289,12 +289,12 @@ public class SpanTest {
 
   @Test
   public void testBaggageOneReference() {
-    io.opentracing.Span parent = tracer.buildSpan("foo").start();
+    io.opentracing.Span parent = tracer.buildSpan("foo").startManual();
     parent.setBaggageItem("foo", "bar");
 
     io.opentracing.Span child = tracer.buildSpan("foo")
         .asChildOf(parent)
-        .start();
+        .startManual();
 
     child.setBaggageItem("a", "a");
 
@@ -305,15 +305,15 @@ public class SpanTest {
 
   @Test
   public void testBaggageMultipleReferences() {
-    io.opentracing.Span parent1 = tracer.buildSpan("foo").start();
+    io.opentracing.Span parent1 = tracer.buildSpan("foo").startManual();
     parent1.setBaggageItem("foo", "bar");
-    io.opentracing.Span parent2 = tracer.buildSpan("foo").start();
+    io.opentracing.Span parent2 = tracer.buildSpan("foo").startManual();
     parent2.setBaggageItem("foo2", "bar");
 
     io.opentracing.Span child = tracer.buildSpan("foo")
         .asChildOf(parent1)
         .addReference(References.FOLLOWS_FROM, parent2.context())
-        .start();
+        .startManual();
 
     child.setBaggageItem("a", "a");
 
@@ -326,7 +326,7 @@ public class SpanTest {
 
   @Test
   public void testImmutableBaggage() {
-    io.opentracing.Span span = tracer.buildSpan("foo").start();
+    io.opentracing.Span span = tracer.buildSpan("foo").startManual();
     span.setBaggageItem("foo", "bar");
     {
       Iterator<Entry<String, String>> baggageIter = span.context().baggageItems().iterator();

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTagsTest.java
@@ -110,9 +110,9 @@ public class TracerTagsTest {
             .withTag("tracer.tag.num", 1)
             .build();
 
-    Span span = (Span) tracer.buildSpan("root").start();
+    Span span = (Span) tracer.buildSpan("root").startManual();
     if (spanType == SpanType.CHILD) {
-      span = (Span) tracer.buildSpan("child").asChildOf(span).start();
+      span = (Span) tracer.buildSpan("child").asChildOf(span).startManual();
     }
     if (spanType == SpanType.RPC_SERVER) {
       span =
@@ -121,7 +121,7 @@ public class TracerTagsTest {
                   .buildSpan("rpc-server")
                   .asChildOf(span)
                   .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-                  .start();
+                  .startManual();
     }
     Map<String, Object> tags = span.getTags();
     for (String key : expectedTags.keySet()) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/TracerTest.java
@@ -59,7 +59,7 @@ public class TracerTest {
   @Test
   public void testBuildSpan() {
     String expectedOperation = "fry";
-    Span span = (Span) tracer.buildSpan(expectedOperation).start();
+    Span span = (Span) tracer.buildSpan(expectedOperation).startManual();
 
     assertEquals(expectedOperation, span.getOperationName());
   }
@@ -67,7 +67,7 @@ public class TracerTest {
   @Test
   public void testTracerMetrics() {
     String expectedOperation = "fry";
-    tracer.buildSpan(expectedOperation).start();
+    tracer.buildSpan(expectedOperation).startManual();
     assertEquals(
         1L, metricsReporter.counters.get("jaeger.spans.group=sampling.sampled=y").longValue());
     assertEquals(
@@ -86,7 +86,7 @@ public class TracerTest {
             .withStatsReporter(metricsReporter)
             .registerInjector(Format.Builtin.TEXT_MAP, injector)
             .build();
-    Span span = (Span) tracer.buildSpan("leela").start();
+    Span span = (Span) tracer.buildSpan("leela").startManual();
 
     TextMap carrier = mock(TextMap.class);
     tracer.inject(span.context(), Format.Builtin.TEXT_MAP, carrier);

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -71,7 +71,7 @@ public class RemoteReporterTest {
 
   @Test
   public void testRemoteReporterReport() throws Exception {
-    Span span = (Span) tracer.buildSpan("raza").start();
+    Span span = (Span) tracer.buildSpan("raza").startManual();
     reporter.report(span);
     // do sleep until automatic flush happens on 'reporter'
     // added 20ms on top of 'flushInterval' to avoid corner cases
@@ -89,7 +89,7 @@ public class RemoteReporterTest {
   public void testRemoteReporterFlushesOnClose() throws Exception {
     int numberOfSpans = 100;
     for (int i = 0; i < numberOfSpans; i++) {
-      Span span = (Span) tracer.buildSpan("raza").start();
+      Span span = (Span) tracer.buildSpan("raza").startManual();
       reporter.report(span);
     }
     reporter.close();
@@ -239,6 +239,6 @@ public class RemoteReporterTest {
   }
 
   private Span newSpan() {
-    return (Span) tracer.buildSpan("x").start();
+    return (Span) tracer.buildSpan("x").startManual();
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/protocols/JaegerThriftSpanConverterTest.java
@@ -121,7 +121,7 @@ public class JaegerThriftSpanConverterTest {
     Map<String, Object> fields = new HashMap<String, Object>();
     fields.put("k", "v");
 
-    Span span = tracer.buildSpan("operation-name").start();
+    Span span = tracer.buildSpan("operation-name").startManual();
     span = span.log(1, "key", "value");
     span = span.log(1, fields);
 
@@ -149,11 +149,11 @@ public class JaegerThriftSpanConverterTest {
 
   @Test
   public void testConvertSpanOneReferenceChildOf() {
-    Span parent = tracer.buildSpan("foo").start();
+    Span parent = tracer.buildSpan("foo").startManual();
 
     Span child = tracer.buildSpan("foo")
         .asChildOf(parent)
-        .start();
+        .startManual();
 
     com.uber.jaeger.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan((com.uber.jaeger.Span) child);
 
@@ -163,13 +163,13 @@ public class JaegerThriftSpanConverterTest {
 
   @Test
   public void testConvertSpanTwoReferencesChildOf() {
-    Span parent = tracer.buildSpan("foo").start();
-    Span parent2 = tracer.buildSpan("foo").start();
+    Span parent = tracer.buildSpan("foo").startManual();
+    Span parent2 = tracer.buildSpan("foo").startManual();
 
     Span child = tracer.buildSpan("foo")
         .asChildOf(parent)
         .asChildOf(parent2)
-        .start();
+        .startManual();
 
     com.uber.jaeger.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan((com.uber.jaeger.Span) child);
 
@@ -181,13 +181,13 @@ public class JaegerThriftSpanConverterTest {
 
   @Test
   public void testConvertSpanMixedReferences() {
-    Span parent = tracer.buildSpan("foo").start();
-    Span parent2 = tracer.buildSpan("foo").start();
+    Span parent = tracer.buildSpan("foo").startManual();
+    Span parent2 = tracer.buildSpan("foo").startManual();
 
     Span child = tracer.buildSpan("foo")
         .addReference(References.FOLLOWS_FROM, parent.context())
         .asChildOf(parent2)
-        .start();
+        .startManual();
 
     com.uber.jaeger.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan((com.uber.jaeger.Span) child);
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
@@ -98,7 +98,7 @@ public class UdpSenderTest {
 
   @Test(expected = SenderException.class)
   public void testAppendSpanTooLarge() throws Exception {
-    Span jaegerSpan = (Span) tracer.buildSpan("raza").start();
+    Span jaegerSpan = (Span) tracer.buildSpan("raza").startManual();
     String msg = "";
     for (int i = 0; i < 10001; i++) {
       msg += ".";
@@ -116,7 +116,7 @@ public class UdpSenderTest {
   @Test
   public void testAppend() throws Exception {
     // find size of the initial span
-    Span jaegerSpan = (Span)tracer.buildSpan("raza").start();
+    Span jaegerSpan = (Span)tracer.buildSpan("raza").startManual();
     com.uber.jaeger.thriftjava.Span span =
             JaegerThriftSpanConverter.convertSpan(jaegerSpan);
 
@@ -154,7 +154,7 @@ public class UdpSenderTest {
   public void testFlushSendsSpan() throws Exception {
     int timeout = 50; // in milliseconds
     int expectedNumSpans = 1;
-    Span expectedSpan = (Span) tracer.buildSpan("raza").start();
+    Span expectedSpan = (Span) tracer.buildSpan("raza").startManual();
     int appendNum = sender.append(expectedSpan);
     int flushNum = sender.flush();
     assertEquals(appendNum, 0);
@@ -192,7 +192,7 @@ public class UdpSenderTest {
     AutoExpandingBufferWriteTransport memoryTransport =
         new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
     Agent.Client memoryClient = new Agent.Client(new TCompactProtocol((memoryTransport)));
-    Span jaegerSpan = (Span) tracer.buildSpan("raza").start();
+    Span jaegerSpan = (Span) tracer.buildSpan("raza").startManual();
     com.uber.jaeger.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan(jaegerSpan);
     List<com.uber.jaeger.thriftjava.Span> spans = new ArrayList<>();
     for (int i = 0; i < numberOfSpans; i++) {

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/EndToEndBehavior.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/EndToEndBehavior.java
@@ -91,7 +91,7 @@ public class EndToEndBehavior {
           builder.withTag(kv.getKey(), kv.getValue());
         }
       }
-      Span span = builder.start();
+      Span span = builder.startManual();
       span.finish();
     }
   }

--- a/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
@@ -98,7 +98,7 @@ public class TraceBehaviorResourceTest {
 
   @Test
   public void testStartTraceHttp() throws Exception {
-    Span span = (Span) server.getTracer().buildSpan("root").start();
+    Span span = (Span) server.getTracer().buildSpan("root").startManual();
     TracingUtils.getTraceContext().push(span);
 
     String expectedTraceId = String.format("%x", span.context().getTraceId());
@@ -123,7 +123,7 @@ public class TraceBehaviorResourceTest {
 
   @Test
   public void testJoinTraceHttp() throws Exception {
-    Span span = (Span) server.getTracer().buildSpan("root").start();
+    Span span = (Span) server.getTracer().buildSpan("root").startManual();
     TracingUtils.getTraceContext().push(span);
 
     String expectedBaggage = "baggage-example";
@@ -157,7 +157,7 @@ public class TraceBehaviorResourceTest {
     TChannelServer tchannel = new TChannelServer(8081, behavior, server.getTracer(), true);
     tchannel.start();
 
-    Span span = (Span) server.getTracer().buildSpan("root").start();
+    Span span = (Span) server.getTracer().buildSpan("root").startManual();
     TracingUtils.getTraceContext().push(span);
 
     String expectedBaggage = "baggage-example";

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -56,7 +56,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
       if (!traceContext.isEmpty()) {
         clientSpanBuilder.asChildOf(traceContext.getCurrentSpan());
       }
-      Span clientSpan = clientSpanBuilder.start();
+      Span clientSpan = clientSpanBuilder.startManual();
 
       Tags.SPAN_KIND.set(clientSpan, Tags.SPAN_KIND_CLIENT);
       Tags.HTTP_URL.set(clientSpan, clientRequestContext.getUri().toString());

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -83,7 +83,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
       if (spanContext != null) {
         builder = builder.asChildOf(spanContext);
       }
-      Span serverSpan = builder.start();
+      Span serverSpan = builder.startManual();
 
       traceContext.push(serverSpan);
     } catch (Exception e) {

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
@@ -95,7 +95,7 @@ public class FilterIntegrationTest {
   public void testJerseyClientReceivesSpan() throws Exception {
     WebTarget target = client.target(server.BASE_URI).path("jersey").path("hop1");
 
-    Span span = (Span) tracer.buildSpan("root-span").start();
+    Span span = (Span) tracer.buildSpan("root-span").startManual();
     span.setBaggageItem(BAGGAGE_KEY, BAGGAGE_VALUE);
     traceContext.push(span);
 

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
@@ -58,7 +58,7 @@ public class ThriftSpanConverterTest {
 
   @Test
   public void testSpanKindServerCreatesAnnotations() {
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").start();
+    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").startManual();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
 
     com.twitter.zipkin.thriftjava.Span zipkinSpan = ThriftSpanConverter.convertSpan(span);
@@ -82,7 +82,7 @@ public class ThriftSpanConverterTest {
 
   @Test
   public void testSpanKindClientCreatesAnnotations() {
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").start();
+    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").startManual();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
 
     com.twitter.zipkin.thriftjava.Span zipkinSpan = ThriftSpanConverter.convertSpan(span);
@@ -107,7 +107,7 @@ public class ThriftSpanConverterTest {
   @Test
   public void testExpectdLocalComponentNameUsed() {
     String expectedCompnentName = "local-name";
-    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").start();
+    Span span = (com.uber.jaeger.Span) tracer.buildSpan("operation-name").startManual();
     Tags.COMPONENT.set(span, expectedCompnentName);
 
     com.twitter.zipkin.thriftjava.Span zipkinSpan = ThriftSpanConverter.convertSpan(span);
@@ -121,7 +121,7 @@ public class ThriftSpanConverterTest {
     int expectedIp = (127 << 24) | 1;
     int expectedPort = 8080;
     String expectedServiceName = "some-peer-service";
-    Span span = (Span) tracer.buildSpan("test-service-operation").start();
+    Span span = (Span) tracer.buildSpan("test-service-operation").startManual();
     Tags.PEER_HOST_IPV4.set(span, expectedIp);
     Tags.PEER_PORT.set(span, expectedPort);
     Tags.PEER_SERVICE.set(span, expectedServiceName);
@@ -133,7 +133,7 @@ public class ThriftSpanConverterTest {
 
   @Test
   public void testSpanDetectsIsClient() {
-    Span span = (Span) tracer.buildSpan("test-service-operation").start();
+    Span span = (Span) tracer.buildSpan("test-service-operation").startManual();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
 
     assertTrue(ThriftSpanConverter.isRpc(span));
@@ -142,7 +142,7 @@ public class ThriftSpanConverterTest {
 
   @Test
   public void testSpanDetectsIsServer() {
-    Span span = (Span) tracer.buildSpan("test-service-operation").start();
+    Span span = (Span) tracer.buildSpan("test-service-operation").startManual();
     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
 
     assertTrue(ThriftSpanConverter.isRpc(span));
@@ -154,7 +154,7 @@ public class ThriftSpanConverterTest {
     String expectedOperation = "parent";
     Span client = (Span) tracer.buildSpan(expectedOperation)
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-        .start();
+        .startManual();
 
     Map<String, String> map = new HashMap<>();
     TextMap carrier = new TextMapInjectAdapter(map);
@@ -167,7 +167,7 @@ public class ThriftSpanConverterTest {
     Span server = (Span)tracer.buildSpan("child")
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
         .asChildOf(ctx)
-        .start();
+        .startManual();
 
     assertEquals("client and server must have the same span ID",
         client.context().getSpanId(), server.context().getSpanId());

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
@@ -73,7 +73,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testAppendSpanTooLarge() throws Exception {
-    Span jaegerSpan = (Span) tracer.buildSpan("raza").start();
+    Span jaegerSpan = (Span) tracer.buildSpan("raza").startManual();
     String msg = "";
     for (int i = 0; i < 1001; i++) {
       msg += ".";
@@ -92,7 +92,7 @@ public class ZipkinSenderTest {
     // find size of the initial span
     AutoExpandingBufferWriteTransport memoryTransport =
         new AutoExpandingBufferWriteTransport(messageMaxBytes, 2);
-    Span jaegerSpan = (Span) tracer.buildSpan("raza").start();
+    Span jaegerSpan = (Span) tracer.buildSpan("raza").startManual();
     com.twitter.zipkin.thriftjava.Span span = ThriftSpanConverter.convertSpan(jaegerSpan);
 
     int expectedNumSpans = 11;
@@ -119,7 +119,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testFlushSendsSpan() throws Exception {
-    Span expectedSpan = (Span) tracer.buildSpan("raza").start();
+    Span expectedSpan = (Span) tracer.buildSpan("raza").startManual();
 
     assertEquals(0, sender.append(expectedSpan));
     assertEquals(1, sender.flush());


### PR DESCRIPTION
Resolves #179 

Changed all calls to `SpanBuilder.start()` method to `startManual()` to avoid deprecation warnings.