### PR TITLE
Support span log fields in zipkin sender

### DIFF
--- a/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverter.java
+++ b/jaeger-zipkin/src/main/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverter.java
@@ -22,6 +22,7 @@
 
 package com.uber.jaeger.senders.zipkin;
 
+import com.google.gson.Gson;
 import com.twitter.zipkin.thriftjava.Annotation;
 import com.twitter.zipkin.thriftjava.AnnotationType;
 import com.twitter.zipkin.thriftjava.BinaryAnnotation;
@@ -42,6 +43,7 @@ import java.util.Map;
 public class ThriftSpanConverter {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final Gson gson = new Gson();
 
   public static com.twitter.zipkin.thriftjava.Span convertSpan(Span span) {
     Tracer tracer = span.getTracer();
@@ -83,32 +85,12 @@ public class ThriftSpanConverter {
         if (logMessage != null) {
           annotations.add(new Annotation(logData.getTime(), logMessage));
         } else if (logFields != null) {
-          annotations.add(new Annotation(logData.getTime(), logFieldsAsMessage(logFields)));
+          annotations.add(new Annotation(logData.getTime(), gson.toJson(logFields)));
         }
       }
     }
 
     return annotations;
-  }
-
-  private static String logFieldsAsMessage(Map<String, ?> logFields) {
-    StringBuilder message = new StringBuilder();
-    String delimiter = "";
-    for (Map.Entry<String, ?> field : logFields.entrySet()) {
-      message.append(delimiter);
-      message.append(field.getKey());
-      message.append("=");
-      Object fieldValue = field.getValue();
-      if (fieldValue instanceof String) {
-        message.append("\"");
-        message.append((String) fieldValue);
-        message.append("\"");
-      } else {
-        message.append(String.valueOf(fieldValue));
-      }
-      delimiter = " ";
-    }
-    return message.toString();
   }
 
   private static List<BinaryAnnotation> buildBinaryAnnotations(Span span, Endpoint host) {

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ThriftSpanConverterTest.java
@@ -303,7 +303,7 @@ public class ThriftSpanConverterTest {
 
     List<String> expectedValues = new ArrayList<String>();
     expectedValues.add("event");
-    expectedValues.add("boolean=true event=\"structured data\" number=42 string=\"something\"");
+    expectedValues.add("{\"boolean\":true,\"event\":\"structured data\",\"number\":42,\"string\":\"something\"}");
 
     assertEquals("zipkin span should contain matching annotations for span logs", expectedValues, annotationValues);
   }

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
@@ -179,7 +179,7 @@ public class ZipkinSenderTest {
 
     Set<String> expectedValues = new HashSet<String>();
     expectedValues.add("event");
-    expectedValues.add("boolean=true event=\"structured data\" number=42 string=\"something\"");
+    expectedValues.add("{\"boolean\":true,\"event\":\"structured data\",\"number\":42,\"string\":\"something\"}");
 
     assertEquals("zipkin span should contain matching annotations for span logs", expectedValues, annotationValues);
   }

--- a/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/com/uber/jaeger/senders/zipkin/ZipkinSenderTest.java
@@ -33,7 +33,11 @@ import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 import org.junit.After;
 import org.junit.Before;
@@ -141,6 +145,43 @@ public class ZipkinSenderTest {
     for (Annotation annotation : actualSpan.annotations) {
       assertEquals(tracer.getServiceName(), annotation.endpoint.serviceName);
     }
+  }
+
+  @Test
+  public void testAppendSpanWithLogs() throws Exception {
+    Span span = (Span) tracer.buildSpan("span-with-logs").startManual();
+
+    span.log("event");
+
+    // use sorted map for consistent ordering in test
+    Map<String, Object> fields = new TreeMap<String, Object>();
+    fields.put("event", "structured data");
+    fields.put("string", "something");
+    fields.put("number", 42);
+    fields.put("boolean", true);
+    span.log(fields);
+
+    sender.append(span);
+    sender.flush();
+
+    List<List<zipkin.Span>> traces = zipkinRule.getTraces();
+    assertEquals(1, traces.size());
+    assertEquals(1, traces.get(0).size());
+
+    zipkin.Span zipkinSpan = traces.get(0).get(0);
+    assertEquals(2, zipkinSpan.annotations.size());
+
+    // ignore order by using set
+    Set<String> annotationValues = new HashSet<String>();
+    for (Annotation annotation : zipkinSpan.annotations) {
+      annotationValues.add(annotation.value);
+    }
+
+    Set<String> expectedValues = new HashSet<String>();
+    expectedValues.add("event");
+    expectedValues.add("boolean=true event=\"structured data\" number=42 string=\"something\"");
+
+    assertEquals("zipkin span should contain matching annotations for span logs", expectedValues, annotationValues);
   }
 
   private ZipkinSender newSender(int messageMaxBytes) {


### PR DESCRIPTION
We're using the Jaeger client to support reporting to both Jaeger and Zipkin. The Zipkin sender currently fails on spans with logs using fields, when the Annotation value (from the LogData message) is null. Recent versions of the Jaeger client also log structured data when baggage is attached, so the Zipkin sender fails on spans with baggage too.

Changes here check whether there is a message or fields, and create a single string message from the structured data fields. An alternative would be to just have the null check and only add annotations for simple message logs.